### PR TITLE
ENH: Wrapping RegisterImages in Python

### DIFF
--- a/Applications/MergeAdjacentImages/CMakeLists.txt
+++ b/Applications/MergeAdjacentImages/CMakeLists.txt
@@ -43,7 +43,7 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/Base/CLI/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES} ITKOptimizers ITKIOTransformBase
-    TubeCLI TubeTKCommon TubeTKRegistration )
+    TubeCLI TubeTKCommon TubeTKRegistration TubeTKITK)
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/Applications/RegisterImages/CMakeLists.txt
+++ b/Applications/RegisterImages/CMakeLists.txt
@@ -43,5 +43,5 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/Base/CLI/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES} ITKOptimizers ITKIOTransformBase
-    TubeTKRegistration TubeCLI)
+    TubeTKRegistration TubeCLI TubeTKITK)
 

--- a/Applications/RegisterImages/README.md
+++ b/Applications/RegisterImages/README.md
@@ -1,0 +1,190 @@
+TubeTK Shrink Image Application
+=============================
+
+---
+*This file is part of [TubeTK](http://www.tubetk.org). TubeTK is developed by [Kitware, Inc.](http://www.kitware.com) and licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).*
+
+#### Overview:
+
+Provides rigid, affine, and BSpline registration methods via a simple UI
+
+Author(s): Stephen R Aylward (Kitware), Casey B Goodlett (Kitware)
+
+Acknowledgements: This work is part of the National Alliance for Medical
+   Image Computing (NAMIC), funded by the National Institutes of Health
+   through the NIH Roadmap for Medical Research, Grant U54 EB005149.
+
+#### Commandline Usage:
+
+   RegisterImages   [--returnparameterfile
+                    <std::string>]
+                    [--processinformationaddress
+                    <std::string>] [--xml] [--echo]
+                    [--controlPointSpacing <int>]
+                    [--bsplineSamplingRatio <float>]
+                    [--bsplineMaxIterations <int>]
+                    [--affineSamplingRatio <float>]
+                    [--affineMaxIterations <int>]
+                    [--rigidSamplingRatio <float>]
+                    [--rigidMaxIterations <int>]
+                    [--movingLandmarks
+                    <std::vector<std::vector<float> >>]
+                    ...  [--fixedLandmarks
+                    <std::vector<std::vector<float> >>]
+                    ...  [--interpolation
+                    <NearestNeighbor|Linear|BSpline>]
+                    [--minimizeMemory]
+                    [--numberOfThreads <int>]
+                    [--randomNumberSeed <int>]
+                    [--fixedImageMask <std::string>]
+                    [--sampleFromOverlap]
+                    [--verbosityLevel <Silent|Standard
+                    |Verbose>] [--expectedSkew <float>]
+                    [--expectedScale <float>]
+                    [--expectedRotation <float>]
+                    [--expectedOffset <float>]
+                    [--metric <MattesMI|NormCorr
+                    |MeanSqrd>] [--registration <None
+                    |Initial|Rigid|Affine|BSpline
+                    |PipelineRigid|PipelineAffine
+                    |PipelineBSpline>]
+                    [--initialization <None|Landmarks
+                    |ImageCenters|CentersOfMass
+                    |SecondMoments>]
+                    [--skipInitialRandomSearch]
+                    [--saveDisplacementField
+                    <std::string>] [--saveTransform
+                    <std::string>] [--loadTransform
+                    <std::string>] [--resampledImage
+                    <std::string>] [--] [--version]
+                    [-h] <std::string> <std::string>
+
+
+Where:
+
+   --returnparameterfile <std::string>
+     Filename in which to write simple return parameters (int, float,
+     int-vector, etc.) as opposed to bulk return parameters (image,
+     geometry, transform, measurement, table).
+
+   --processinformationaddress <std::string>
+     Address of a structure to store process information (progress, abort,
+     etc.). (default: 0)
+
+   --xml
+     Produce xml description of command line arguments (default: 0)
+
+   --echo
+     Echo the command line arguments (default: 0)
+
+   --controlPointSpacing <int>
+     Number of pixels between control points (default: 40)
+
+   --bsplineSamplingRatio <float>
+     Portion of the image to use in computing the metric during BSpline
+     registration (default: 0.1)
+
+   --bsplineMaxIterations <int>
+     Maximum number of bspline optimization iterations (default: 20)
+
+   --affineSamplingRatio <float>
+     Portion of the image to use in computing the metric during affine
+     registration (default: 0.02)
+
+   --affineMaxIterations <int>
+     Maximum number of affine optimization iterations (default: 50)
+
+   --rigidSamplingRatio <float>
+     Portion of the image to use in computing the metric during rigid
+     registration (default: 0.01)
+
+   --rigidMaxIterations <int>
+     Maximum number of rigid optimization iterations (default: 100)
+
+   --movingLandmarks <std::vector<std::vector<float> >>  (accepted multiple
+      times)
+     Ordered list of landmarks in the moving image
+
+   --fixedLandmarks <std::vector<std::vector<float> >>  (accepted multiple
+      times)
+     Ordered list of landmarks in the fixed image
+
+   --interpolation <NearestNeighbor|Linear|BSpline>
+     Method for interpolation within the optimization process (default:
+     Linear)
+
+   --minimizeMemory
+     Reduce the amount of memory required at the cost of increased
+     computation time (default: 0)
+
+   --numberOfThreads <int>
+     Number of CPU threads to use (default: 0)
+
+   --randomNumberSeed <int>
+     Seed to generate a consistent random number sequence (default: 0)
+
+   --fixedImageMask <std::string>
+     Image which defines a mask for the fixed image
+
+   --sampleFromOverlap
+     Limit metric evaluation to the fixed image region overlapped by the
+     moving image (default: 0)
+
+   --verbosityLevel <Silent|Standard|Verbose>
+     Level of detail of reporting progress (default: Standard)
+
+   --expectedSkew <float>
+     Expected misalignment after initialization (default: 0.01)
+
+   --expectedScale <float>
+     Expected misalignment after initialization (default: 0.05)
+
+   --expectedRotation <float>
+     Expected misalignment after initialization (default: 0.1)
+
+   --expectedOffset <float>
+     Expected misalignment after initialization (default: 10)
+
+   --metric <MattesMI|NormCorr|MeanSqrd>
+     Method to quantify image match (default: MattesMI)
+
+   --registration <None|Initial|Rigid|Affine|BSpline|PipelineRigid
+      |PipelineAffine|PipelineBSpline>
+     Method for the registration process (default: PipelineAffine)
+
+   --initialization <None|Landmarks|ImageCenters|CentersOfMass
+      |SecondMoments>
+     Method to prime the registration process (default: CentersOfMass)
+
+   --skipInitialRandomSearch
+     Skips initial random search (skips the evolutionary optimizer) during
+     the registration process and uses only the gradient optimizer
+
+   --saveDisplacementField <std::string>
+     Save displacement field result from registration
+
+   --saveTransform <std::string>
+     Save the transform that results from registration
+
+   --loadTransform <std::string>
+     Load a transform that is immediately applied to the moving image
+
+   --resampledImage <std::string>
+     Registration results
+
+   --,  --ignore_rest
+     Ignores the rest of the labeled arguments following this flag.
+
+   --version
+     Displays version information and exits.
+
+   -h,  --help
+     Displays usage information and exits.
+
+   <std::string>
+     (required)  Image which defines the space into which the moving image
+     is registered
+
+   <std::string>
+     (required)  The transform goes from the fixed image's space into the
+     moving image's space

--- a/Base/Registration/itktubeImageToImageRegistrationHelper.h
+++ b/Base/Registration/itktubeImageToImageRegistrationHelper.h
@@ -15,8 +15,8 @@
 
 =========================================================================*/
 
-#ifndef __itkImageToImageRegistrationHelper_h
-#define __itkImageToImageRegistrationHelper_h
+#ifndef __itktubeImageToImageRegistrationHelper_h
+#define __itktubeImageToImageRegistrationHelper_h
 
 #include "itkImage.h"
 #include "itkCommand.h"
@@ -28,10 +28,12 @@
 #include "itkAffineImageToImageRegistrationMethod.h"
 #include "itkBSplineImageToImageRegistrationMethod.h"
 
+
 namespace itk
 {
-
-template <class TImage>
+namespace tube
+{
+template <class TImage, class TTransformPrecisionType = double>
 class ImageToImageRegistrationHelper : public Object
 {
 
@@ -77,6 +79,15 @@ public:
   typedef BSplineImageToImageRegistrationMethod<TImage>
   BSplineRegistrationMethodType;
 
+  typedef TransformBaseTemplate<TTransformPrecisionType>
+  TransformType;
+
+  typedef typename TransformType::Pointer
+  TransformPointer;
+
+  typedef typename std::list< TransformPointer >
+  TransformListType;
+
   //
   // Typedefs for the parameters of the registration methods
   //
@@ -121,6 +132,11 @@ public:
   typedef typename BSplineRegistrationMethodType::TransformType
   BSplineTransformType;
 
+  typedef itk::Vector<PixelType,TImage::ImageDimension>  VectorType;
+
+  typedef typename itk::Image<VectorType,TImage::ImageDimension>
+  DisplacementFieldType;
+
   //
   // Custom Methods
   //
@@ -130,20 +146,15 @@ public:
   //  Specify the fixed and moving images
   // **************
   // **************
-  void LoadFixedImage( const std::string & filename );
 
   itkSetConstObjectMacro( FixedImage, TImage );
   itkGetConstObjectMacro( FixedImage, TImage );
-
-  void LoadMovingImage( const std::string & filename );
 
   itkSetConstObjectMacro( MovingImage, TImage );
   itkGetConstObjectMacro( MovingImage, TImage );
 
   // **************
-  //  Generic file-save function
   // **************
-  void SaveImage( const std::string & filename, const TImage * image );
 
   itkSetMacro( RandomNumberSeed, unsigned int );
   itkGetMacro( RandomNumberSeed, unsigned int );
@@ -228,14 +239,16 @@ public:
   // **************
 
   // Specify the baseline image.
-  void LoadBaselineImage( const std::string & filename );
-
   itkSetConstObjectMacro( BaselineImage, TImage );
+  itkGetConstObjectMacro( BaselineImage, TImage );
 
   // Bound the required accuracy for the registration test to "pass"
   itkSetMacro( BaselineNumberOfFailedPixelsTolerance,  unsigned int );
+  itkGetMacro( BaselineNumberOfFailedPixelsTolerance,  unsigned int );
   itkSetMacro( BaselineIntensityTolerance, PixelType );
+  itkGetMacro( BaselineIntensityTolerance, PixelType );
   itkSetMacro( BaselineRadiusTolerance, unsigned int );
+  itkGetMacro( BaselineRadiusTolerance, unsigned int );
 
   // Must be called after setting the BaselineImage in order to resample
   //   the moving image into the BaselineImage space, compute differences,
@@ -315,13 +328,6 @@ public:
   itkGetConstObjectMacro( BSplineTransformResampledImage, TImage );
 
   // **************
-  //  Not implemented at this time :(
-  // **************
-  void LoadParameters( const std::string & filename );
-
-  void SaveParameters( const std::string & filename );
-
-  // **************
   //  Final metric value after the pipeline has completed
   // **************
   itkGetMacro( FinalMetricValue, double );
@@ -340,11 +346,12 @@ public:
   //
   // Loaded transforms parameters
   //
-  void LoadTransform( const std::string & filename );
 
-  void SaveTransform( const std::string & filename );
+  void SetTransformList( const TransformListType &transforms );
 
-  void SaveDisplacementField( const std::string &filename );
+  TransformListType GetTransformList();
+
+  DisplacementFieldType* GetDisplacementField();
 
   void SetLoadedMatrixTransform( const MatrixTransformType & tfm );
 
@@ -428,6 +435,11 @@ public:
 
   itkGetConstObjectMacro( BSplineTransform, BSplineTransformType );
   itkGetMacro( BSplineMetricValue, double );
+
+  // Get for Print in ITKTubeTK
+  itkGetMacro(CompletedInitialization, bool);
+  itkGetMacro(CompletedResampling,bool);
+  itkGetConstObjectMacro(InitialTransform,InitialTransformType);
 protected:
 
   ImageToImageRegistrationHelper( void );
@@ -559,11 +571,11 @@ private:
   double m_BSplineMetricValue;
 
 };
-
-}
+}//end of tube namespace
+}//end of itk namespace
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "itkImageToImageRegistrationHelper.txx"
+#include "itktubeImageToImageRegistrationHelper.hxx"
 #endif
 
 #endif

--- a/Base/Registration/itktubeImageToImageRegistrationHelper.hxx
+++ b/Base/Registration/itktubeImageToImageRegistrationHelper.hxx
@@ -14,13 +14,11 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef __itkImageToImageRegistrationHelper_txx
-#define __itkImageToImageRegistrationHelper_txx
+#ifndef __itktubeImageToImageRegistrationHelper_hxx
+#define __itktubeImageToImageRegistrationHelper_hxx
 
-#include "itkImageToImageRegistrationHelper.h"
+#include "itktubeImageToImageRegistrationHelper.h"
 
-#include "itkImageFileReader.h"
-#include "itkImageFileWriter.h"
 #include "itkResampleImageFilter.h"
 #include "itkTestingComparisonImageFilter.h"
 #include "itkInterpolateImageFunction.h"
@@ -28,8 +26,6 @@
 #include "itkLinearInterpolateImageFunction.h"
 #include "itkBSplineInterpolateImageFunction.h"
 #include "itkWindowedSincInterpolateImageFunction.h"
-#include "itkTransformFileReader.h"
-#include "itkTransformFileWriter.h"
 #include "itkTransformFactory.h"
 #include "itkSubtractImageFilter.h"
 #include "itkMinimumMaximumImageCalculator.h"
@@ -37,9 +33,10 @@
 
 namespace itk
 {
-
-template <class TImage>
-ImageToImageRegistrationHelper<TImage>
+namespace tube
+{
+template <class TImage, class TTransformPrecisionType>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::ImageToImageRegistrationHelper()
 {
   // Data
@@ -105,7 +102,7 @@ ImageToImageRegistrationHelper<TImage>
 
   m_MinimizeMemory = false;
   // Optimizer
-  m_UseEvolutionaryOptimization = true ;
+  m_UseEvolutionaryOptimization = true;
   // Loaded
   m_LoadedMatrixTransform = NULL;
   m_LoadedBSplineTransform = NULL;
@@ -150,71 +147,15 @@ ImageToImageRegistrationHelper<TImage>
 
 }
 
-template <class TImage>
-ImageToImageRegistrationHelper<TImage>
+template <class TImage, class TTransformPrecisionType>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::~ImageToImageRegistrationHelper()
 {
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
-::LoadFixedImage( const std::string & filename )
-{
-  typedef ImageFileReader<TImage> ImageReaderType;
-
-  typename ImageReaderType::Pointer imageReader = ImageReaderType::New();
-
-  imageReader->SetFileName( filename );
-
-  imageReader->Update();
-
-  SetFixedImage( imageReader->GetOutput() );
-
-  m_CompletedStage = PRE_STAGE;
-
-  m_CompletedInitialization = false;
-  m_CompletedResampling = false;
-}
-
-template <class TImage>
-void
-ImageToImageRegistrationHelper<TImage>
-::LoadMovingImage( const std::string & filename )
-{
-  typedef ImageFileReader<TImage> ImageReaderType;
-
-  typename ImageReaderType::Pointer imageReader = ImageReaderType::New();
-
-  imageReader->SetFileName( filename );
-
-  imageReader->Update();
-
-  SetMovingImage( imageReader->GetOutput() );
-
-  m_CompletedStage = PRE_STAGE;
-
-  m_CompletedInitialization = false;
-  m_CompletedResampling = false;
-}
-
-template <class TImage>
-void
-ImageToImageRegistrationHelper<TImage>
-::SaveImage( const std::string & filename, const TImage * image )
-{
-  typedef ImageFileWriter<TImage> FileWriterType;
-
-  typename FileWriterType::Pointer fileWriter = FileWriterType::New();
-  fileWriter->SetUseCompression( true );
-  fileWriter->SetInput( image );
-  fileWriter->SetFileName( filename );
-  fileWriter->Update();
-}
-
-template <class TImage>
-void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::SetFixedImageMaskObject( const MaskObjectType * maskObject )
 {
   if( this->m_FixedImageMaskObject.GetPointer() != maskObject )
@@ -234,9 +175,9 @@ ImageToImageRegistrationHelper<TImage>
     }
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::SetMovingImageMaskObject( const MaskObjectType * maskObject )
 {
   if( this->m_MovingImageMaskObject.GetPointer() != maskObject )
@@ -256,9 +197,9 @@ ImageToImageRegistrationHelper<TImage>
     }
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::Initialize( void )
 {
   // m_LoadedTransform = 0;  Not Initialized - since it is a user parameter
@@ -299,9 +240,9 @@ ImageToImageRegistrationHelper<TImage>
 
 /** This class provides an Update() method to fit the appearance of a
  * ProcessObject API, but it is not a ProcessObject.  */
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::Update( void )
 {
   if( !(this->m_CompletedInitialization) )
@@ -782,9 +723,9 @@ ImageToImageRegistrationHelper<TImage>
   // this->SaveImage("c:/result.mha",m_CurrentMovingImage);
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 typename TImage::ConstPointer
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::ResampleImage( InterpolationMethodEnumType interpolationMethod,
                  const ImageType * movingImage,
                  const MatrixTransformType * matrixTransform,
@@ -1076,33 +1017,17 @@ ImageToImageRegistrationHelper<TImage>
   return mImage;
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 typename TImage::ConstPointer
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::GetFinalMovingImage( InterpolationMethodEnumType interpolationMethod )
 {
   return ResampleImage( interpolationMethod );
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
-::LoadBaselineImage( const std::string & filename )
-{
-  typedef ImageFileReader<TImage> ImageReaderType;
-
-  typename ImageReaderType::Pointer imageReader = ImageReaderType::New();
-
-  imageReader->SetFileName( filename );
-
-  imageReader->Update();
-
-  SetBaselineImage( imageReader->GetOutput() );
-}
-
-template <class TImage>
-void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::ComputeBaselineDifference()
 {
   if( m_BaselineImage.IsNull() )
@@ -1148,38 +1073,16 @@ ImageToImageRegistrationHelper<TImage>
     }
 }
 
-template <class TImage>
+
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
-::LoadParameters( const std::string & itkNotUsed(filename) )
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
+::SetTransformList( const TransformListType &transforms )
 {
-}
-
-template <class TImage>
-void
-ImageToImageRegistrationHelper<TImage>
-::SaveParameters( const std::string & itkNotUsed(filename) )
-{
-}
-
-template <class TImage>
-void
-ImageToImageRegistrationHelper<TImage>
-::LoadTransform( const std::string & filename )
-{
-  typedef TransformFileReader                    TransformReaderType;
-  typedef TransformReaderType::TransformListType TransformListType;
-
-  TransformReaderType::Pointer transformReader = TransformReaderType::New();
-  transformReader->SetFileName( filename );
-
   TransformFactory<BSplineTransformType>::RegisterTransform();
 
-  transformReader->Update();
-
-  TransformListType *transforms = transformReader->GetTransformList();
-  TransformListType::const_iterator transformIt = transforms->begin();
-  while( transformIt != transforms->end() )
+  typename TransformListType::const_iterator transformIt = transforms.begin();
+  while( transformIt != transforms.end() )
     {
     if( !strcmp( (*transformIt)->GetNameOfClass(), "AffineTransform") )
       {
@@ -1204,42 +1107,38 @@ ImageToImageRegistrationHelper<TImage>
     }
 }
 
-template <class TImage>
-void
-ImageToImageRegistrationHelper<TImage>
-::SaveTransform( const std::string & filename )
+template <class TImage, class TTransformPrecisionType>
+typename ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
+::TransformListType
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
+::GetTransformList()
 {
-  typedef TransformFileWriter TransformWriterType;
-
-  TransformWriterType::Pointer transformWriter = TransformWriterType::New();
-  transformWriter->SetFileName( filename );
+  TransformListType transformList;
 
   TransformFactory<BSplineTransformType>::RegisterTransform();
 
   if( m_CurrentMatrixTransform.IsNotNull() )
     {
-    transformWriter->SetInput( m_CurrentMatrixTransform );
+    transformList.push_back(m_CurrentMatrixTransform.GetPointer());
     if( m_CurrentBSplineTransform.IsNotNull() )
       {
-      transformWriter->AddTransform( m_CurrentBSplineTransform );
+      transformList.push_back(m_CurrentBSplineTransform.GetPointer());
       }
-    transformWriter->Update();
     }
   else if( m_CurrentBSplineTransform.IsNotNull() )
     {
-    transformWriter->SetInput( m_CurrentBSplineTransform );
-    transformWriter->Update();
+    transformList.push_back(m_CurrentBSplineTransform.GetPointer());
     }
+  return transformList;
 }
 
-template <class TImage>
-void
-ImageToImageRegistrationHelper<TImage>
-::SaveDisplacementField( const std::string &filename )
+template <class TImage, class TTransformPrecisionType>
+typename ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
+::DisplacementFieldType*
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
+::GetDisplacementField()
 {
-  typedef itk::Vector<PixelType,TImage::ImageDimension>  VectorType;
-  typedef itk::Image<VectorType,TImage::ImageDimension>  DisplacementFieldType;
-  typedef itk::ImageRegionIterator< DisplacementFieldType > FieldIterator;
+  typedef typename itk::ImageRegionIterator< DisplacementFieldType > FieldIterator;
 
   typename TImage::RegionType fixedImageRegion =
     m_FixedImage->GetBufferedRegion();
@@ -1286,19 +1185,12 @@ ImageToImageRegistrationHelper<TImage>
     it.Set( dx );
     ++it;
     }
-
-  typedef itk::ImageFileWriter< DisplacementFieldType >  FieldWriterType;
-  typename FieldWriterType::Pointer fieldWriter = FieldWriterType::New();
-
-  fieldWriter->SetInput( field );
-  fieldWriter->SetFileName( filename );
-
-  fieldWriter->Update();
+  return field;
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::SetLoadedMatrixTransform( const MatrixTransformType & tfm )
 {
   m_LoadedMatrixTransform = MatrixTransformType::New();
@@ -1312,9 +1204,9 @@ ImageToImageRegistrationHelper<TImage>
   m_CurrentMovingImage = m_MovingImage;
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::SetLoadedBSplineTransform( const BSplineTransformType & tfm )
 {
   m_LoadedBSplineTransform = BSplineTransformType::New();
@@ -1326,9 +1218,9 @@ ImageToImageRegistrationHelper<TImage>
   m_CurrentMovingImage = m_MovingImage;
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::SetRegionOfInterest( const PointType & point1,
                        const PointType & point2 )
 {
@@ -1337,9 +1229,9 @@ ImageToImageRegistrationHelper<TImage>
   m_UseRegionOfInterest = true;
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::SetRegionOfInterest( const std::vector<float> & points )
 {
   if( points.size() != 2 * ImageDimension )
@@ -1355,9 +1247,9 @@ ImageToImageRegistrationHelper<TImage>
   m_UseRegionOfInterest = true;
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::SetFixedLandmarks( const std::vector<std::vector<float> > & fixedLandmarks )
 {
   m_FixedLandmarks.clear();
@@ -1371,9 +1263,9 @@ ImageToImageRegistrationHelper<TImage>
     }
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::SetMovingLandmarks( const std::vector<std::vector<float> > & movingLandmarks )
 {
   m_MovingLandmarks.clear();
@@ -1387,9 +1279,9 @@ ImageToImageRegistrationHelper<TImage>
     }
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::PrintSelfHelper( std::ostream & os, Indent indent,
                    const std::string & basename,
                    MetricMethodEnumType metric,
@@ -1441,9 +1333,9 @@ ImageToImageRegistrationHelper<TImage>
     }
 }
 
-template <class TImage>
+template <class TImage, class TTransformPrecisionType>
 void
-ImageToImageRegistrationHelper<TImage>
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
 ::PrintSelf( std::ostream & os, Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );
@@ -1698,6 +1590,7 @@ ImageToImageRegistrationHelper<TImage>
 
 }
 
-}
+}//end of tube namespace
+}//end of itk namespace
 
 #endif

--- a/ITKModules/TubeTKITK/include/tubeImageToImageRegistrationHelper.h
+++ b/ITKModules/TubeTKITK/include/tubeImageToImageRegistrationHelper.h
@@ -1,0 +1,396 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+*=========================================================================*/
+#ifndef __tubeImageToImageRegistrationHelper_h
+#define __tubeImageToImageRegistrationHelper_h
+
+#include "itktubeImageToImageRegistrationHelper.h"
+#include "itkObject.h"
+#include "tubeWrappingMacros.h"
+
+namespace tube
+{
+/** \class ImageToImageRegistrationHelper
+ *
+ *  \ingroup TubeTKITK
+ */
+
+
+template< class TImage, class TTransformPrecisionType = double >
+class ImageToImageRegistrationHelper:
+  public itk::ProcessObject
+{
+public:
+  /** Standard class typedefs. */
+  typedef ImageToImageRegistrationHelper                  Self;
+  typedef itk::SmartPointer< Self >                       Pointer;
+  typedef itk::SmartPointer< const Self >                 ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro( Self );
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro( ImageToImageRegistrationHelper, Object );
+
+
+  /** Typedef to images */
+  typedef TImage                           ImageType;
+  typedef TTransformPrecisionType          TransformPrecisionType;
+
+  itkStaticConstMacro( ImageDimension, unsigned int,
+                       TImage::ImageDimension );
+
+  typedef itk::tube::ImageToImageRegistrationHelper< ImageType, TransformPrecisionType >
+  FilterType;
+  //
+  // Typedefs for the parameters of the registration methods
+  //
+  typedef typename  FilterType::MaskObjectType             MaskObjectType;
+  typedef typename FilterType::PointType                   PointType;
+  typedef typename FilterType::InterpolationMethodEnumType InterpolationMethodEnumType;
+  //
+  // Available Registration Methods
+  //
+  typedef typename FilterType::OptimizedRegistrationMethodType
+  OptimizedRegistrationMethodType;
+
+  typedef typename FilterType::MatrixTransformType             MatrixTransformType;
+  typedef typename FilterType::BSplineTransformType            BSplineTransformType;
+  typedef typename FilterType::PixelType                       PixelType;
+  typedef typename FilterType::TransformListType               TransformListType;
+  typedef typename FilterType::DisplacementFieldType           DisplacementFieldType;
+
+  typedef typename FilterType::LandmarkVectorType              LandmarkVectorType;
+  typedef typename FilterType::RigidTransformType              RigidTransformType;
+  typedef typename FilterType::AffineTransformType             AffineTransformType;
+
+  typedef typename FilterType::MetricMethodEnumType            MetricMethodEnumType;
+  typedef typename FilterType::InitialMethodEnumType           InitialMethodEnumType;
+
+
+  // **************
+  // **************
+  //  Specify the fixed and moving images
+  // **************
+  // **************
+  tubeWrapSetConstObjectMacro( FixedImage, ImageType, RegistrationHelper );
+  tubeWrapGetConstObjectMacro( FixedImage, ImageType, RegistrationHelper );
+
+  tubeWrapSetConstObjectMacro( MovingImage, ImageType, RegistrationHelper );
+  tubeWrapGetConstObjectMacro( MovingImage, ImageType, RegistrationHelper );
+
+  // **************
+  // **************
+  tubeWrapSetMacro( RandomNumberSeed, unsigned int, RegistrationHelper );
+  tubeWrapGetMacro( RandomNumberSeed, unsigned int, RegistrationHelper );
+  // **************
+  // **************
+  //  Specify how the fixed image should be sampled when computing the metric and
+  //    what ROI of the moving image is valid
+  // **************
+  // **************
+  tubeWrapSetMacro( UseFixedImageMaskObject, bool, RegistrationHelper );
+  tubeWrapGetConstMacro( UseFixedImageMaskObject, bool, RegistrationHelper );
+  tubeWrapBooleanMacro( UseFixedImageMaskObject, RegistrationHelper );
+
+  tubeWrapSetConstObjectMacro( FixedImageMaskObject, MaskObjectType,
+                               RegistrationHelper );
+
+  tubeWrapSetMacro( UseRegionOfInterest, bool, RegistrationHelper );
+  tubeWrapGetMacro( UseRegionOfInterest, bool, RegistrationHelper );
+  tubeWrapSetMacro( RegionOfInterestPoint1, PointType, RegistrationHelper );
+  tubeWrapGetMacro( RegionOfInterestPoint1, PointType, RegistrationHelper );
+  tubeWrapSetMacro( RegionOfInterestPoint2, PointType, RegistrationHelper );
+  tubeWrapGetMacro( RegionOfInterestPoint2, PointType, RegistrationHelper );
+
+  void SetRegionOfInterest( const PointType & point1, const PointType & point2 );
+
+  void SetRegionOfInterest( const std::vector<float> & points );
+  // **************
+  //  Initialize the moving image mask as the region of initial overlap
+  //  between the fixed and moving images
+  // **************
+  tubeWrapSetMacro( SampleFromOverlap, bool, RegistrationHelper );
+  tubeWrapGetMacro( SampleFromOverlap, bool, RegistrationHelper );
+  tubeWrapBooleanMacro( SampleFromOverlap, RegistrationHelper );
+
+  tubeWrapSetMacro( SampleIntensityPortion, double, RegistrationHelper );
+  tubeWrapGetConstMacro( SampleIntensityPortion, double, RegistrationHelper );
+  // **************
+  // **************
+  //  Update
+  // **************
+  // **************
+  tubeWrapCallMacro( Initialize, RegistrationHelper );
+  /** This class provides an Update() method to fit the appearance of a
+   * ProcessObject API, but it is not a ProcessObject.  */
+  tubeWrapCallMacro( Update, RegistrationHelper );
+
+  typename ImageType::ConstPointer  ResampleImage(
+    InterpolationMethodEnumType interp
+      = OptimizedRegistrationMethodType
+        ::LINEAR_INTERPOLATION, const ImageType * movingImage = NULL,
+    const MatrixTransformType * matrixTransform = NULL,
+    const BSplineTransformType * bsplineTransform = NULL,
+    PixelType defaultPixelValue = 0);
+
+  // Returns the moving image resampled into the space of the fixed image
+  typename ImageType::ConstPointer GetFinalMovingImage(InterpolationMethodEnumType interp
+                                                       = OptimizedRegistrationMethodType
+                                                         ::LINEAR_INTERPOLATION);
+
+  // **************
+  // **************
+  // Compute registration "accuracy" by comparing a resampled moving image
+  // with a baseline image.
+  // **************
+  // **************
+
+  // Specify the baseline image.
+  tubeWrapSetConstObjectMacro( BaselineImage, ImageType,
+                               RegistrationHelper );
+  // Bound the required accuracy for the registration test to "pass"
+  tubeWrapSetMacro( BaselineNumberOfFailedPixelsTolerance, unsigned int,
+                    RegistrationHelper );
+  tubeWrapSetMacro( BaselineIntensityTolerance, PixelType, RegistrationHelper );
+  tubeWrapSetMacro( BaselineRadiusTolerance, unsigned int, RegistrationHelper );
+
+  // Must be called after setting the BaselineImage in order to resample
+  //   the moving image into the BaselineImage space, compute differences,
+  //   and determine if it passed the test within the specified tolerances
+  tubeWrapCallMacro( ComputeBaselineDifference, RegistrationHelper );
+
+  tubeWrapGetConstObjectMacro( BaselineDifferenceImage, ImageType, RegistrationHelper );
+  tubeWrapGetConstObjectMacro( BaselineResampledMovingImage, ImageType,
+                               RegistrationHelper );
+  tubeWrapGetMacro( BaselineNumberOfFailedPixels, unsigned int, RegistrationHelper );
+  tubeWrapGetMacro( BaselineTestPassed, bool, RegistrationHelper );
+
+  // **************
+  // **************
+  // Process Control
+  // **************
+  // **************
+
+  // **************
+  // Control which steps of the registration pipeline are applied
+  // **************
+
+  tubeWrapSetMacro( EnableLoadedRegistration, bool, RegistrationHelper );
+  tubeWrapGetConstMacro( EnableLoadedRegistration, bool, RegistrationHelper );
+  tubeWrapBooleanMacro( EnableLoadedRegistration, RegistrationHelper );
+
+  tubeWrapSetMacro( EnableInitialRegistration, bool, RegistrationHelper );
+  tubeWrapGetConstMacro( EnableInitialRegistration, bool, RegistrationHelper );
+  tubeWrapBooleanMacro( EnableInitialRegistration, RegistrationHelper );
+
+  tubeWrapSetMacro( EnableRigidRegistration, bool, RegistrationHelper );
+  tubeWrapGetConstMacro( EnableRigidRegistration, bool, RegistrationHelper );
+  tubeWrapBooleanMacro( EnableRigidRegistration, RegistrationHelper );
+
+  tubeWrapSetMacro( EnableAffineRegistration, bool, RegistrationHelper );
+  tubeWrapGetConstMacro( EnableAffineRegistration, bool, RegistrationHelper );
+  tubeWrapBooleanMacro( EnableAffineRegistration, RegistrationHelper );
+
+  tubeWrapSetMacro( EnableBSplineRegistration, bool, RegistrationHelper );
+  tubeWrapGetConstMacro( EnableBSplineRegistration, bool, RegistrationHelper );
+  tubeWrapBooleanMacro( EnableBSplineRegistration, RegistrationHelper );
+
+  // **************
+  // Specify the optimizer
+  // **************
+  tubeWrapSetMacro( UseEvolutionaryOptimization, bool, RegistrationHelper );
+  tubeWrapGetMacro( UseEvolutionaryOptimization, bool, RegistrationHelper );
+  // **************
+  // Specify the expected magnitudes within the transform.  Used to
+  //   guide the operating space of the optimizers
+  // **************
+  tubeWrapSetMacro( ExpectedOffsetPixelMagnitude, double, RegistrationHelper );
+  tubeWrapGetConstMacro( ExpectedOffsetPixelMagnitude, double, RegistrationHelper );
+
+  tubeWrapSetMacro( ExpectedRotationMagnitude, double, RegistrationHelper);
+  tubeWrapGetConstMacro( ExpectedRotationMagnitude, double, RegistrationHelper );
+
+  tubeWrapSetMacro( ExpectedScaleMagnitude, double, RegistrationHelper );
+  tubeWrapGetConstMacro( ExpectedScaleMagnitude, double, RegistrationHelper );
+
+  tubeWrapSetMacro( ExpectedSkewMagnitude, double, RegistrationHelper );
+  tubeWrapGetConstMacro( ExpectedSkewMagnitude, double, RegistrationHelper );
+  // **************
+  //  Return the current product of the registration pipeline
+  // **************
+  tubeWrapGetConstObjectMacro( CurrentMatrixTransform, MatrixTransformType,
+                               RegistrationHelper );
+  tubeWrapGetConstObjectMacro( CurrentBSplineTransform, BSplineTransformType,
+                               RegistrationHelper );
+
+  // The image used for registration is updated at certain points in the
+  //   registration pipeline for speed and transform composition.
+  // Specifically, the image is resmpled using the loaded transforms prior
+  //   to running the initial registration method and the image is resampled
+  //   after the affine registration / prior to running bspline registration
+  // The result of these resamplings is available as the CurrentMovingImage.
+  tubeWrapGetConstObjectMacro( CurrentMovingImage, ImageType, RegistrationHelper );
+  tubeWrapGetConstObjectMacro( LoadedTransformResampledImage, ImageType,
+                               RegistrationHelper );
+  tubeWrapGetConstObjectMacro( MatrixTransformResampledImage, ImageType,
+                               RegistrationHelper );
+  tubeWrapGetConstObjectMacro( BSplineTransformResampledImage, ImageType,
+                               RegistrationHelper );
+  // **************
+  //  Final metric value after the pipeline has completed
+  // **************
+  tubeWrapGetMacro( FinalMetricValue, double, RegistrationHelper );
+  // **************
+  //  Determine if progress messages should be sent to cout
+  // **************
+  tubeWrapSetMacro( ReportProgress, bool, RegistrationHelper );
+  tubeWrapGetMacro( ReportProgress, bool, RegistrationHelper );
+  tubeWrapBooleanMacro( ReportProgress, RegistrationHelper );
+
+  tubeWrapSetMacro( MinimizeMemory, bool, RegistrationHelper );
+  tubeWrapGetMacro( MinimizeMemory, bool, RegistrationHelper );
+  tubeWrapBooleanMacro( MinimizeMemory, RegistrationHelper );
+  //
+  // Loaded transforms parameters
+  //
+  void SetLoadedMatrixTransform( const MatrixTransformType & tfm );
+  tubeWrapGetConstObjectMacro( LoadedMatrixTransform, MatrixTransformType,
+                               RegistrationHelper );
+  void SetLoadedBSplineTransform( const BSplineTransformType & tfm );
+  tubeWrapGetConstObjectMacro( LoadedBSplineTransform, BSplineTransformType,
+                               RegistrationHelper );
+
+  tubeWrapSetMacro( TransformList, TransformListType, RegistrationHelper );
+  tubeWrapGetMacro( TransformList, TransformListType, RegistrationHelper );
+  tubeWrapGetObjectMacro( DisplacementField, DisplacementFieldType, RegistrationHelper );
+
+  //
+  // Initial Parameters
+  //
+  void SetFixedLandmarks( const LandmarkVectorType & fixedLandmarks );
+  void SetMovingLandmarks( const LandmarkVectorType & movingLandmarks );
+
+  tubeWrapSetMacro( InitialMethodEnum, InitialMethodEnumType, RegistrationHelper );
+  tubeWrapGetConstMacro( InitialMethodEnum, InitialMethodEnumType, RegistrationHelper );
+
+  //
+  // Rigid Parameters
+  //
+
+  tubeWrapSetMacro( RigidSamplingRatio, double, RegistrationHelper );
+  tubeWrapGetConstMacro( RigidSamplingRatio, double, RegistrationHelper );
+
+  tubeWrapSetMacro( RigidTargetError, double, RegistrationHelper );
+  tubeWrapGetConstMacro( RigidTargetError, double, RegistrationHelper );
+
+  tubeWrapSetMacro( RigidMaxIterations, unsigned int, RegistrationHelper );
+  tubeWrapGetConstMacro( RigidMaxIterations, unsigned int, RegistrationHelper );
+
+  tubeWrapSetMacro( RigidMetricMethodEnum, MetricMethodEnumType, RegistrationHelper );
+  tubeWrapGetConstMacro( RigidMetricMethodEnum, MetricMethodEnumType,
+                         RegistrationHelper );
+
+  tubeWrapSetMacro( RigidInterpolationMethodEnum, InterpolationMethodEnumType,
+                    RegistrationHelper );
+  tubeWrapGetConstMacro( RigidInterpolationMethodEnum, InterpolationMethodEnumType,
+                         RegistrationHelper );
+
+  tubeWrapGetConstObjectMacro( RigidTransform, RigidTransformType,
+                               RegistrationHelper );
+  tubeWrapGetMacro( RigidMetricValue, double, RegistrationHelper );
+
+  //
+  // Affine Parameters
+  //
+
+  tubeWrapSetMacro( AffineSamplingRatio, double, RegistrationHelper );
+  tubeWrapGetConstMacro( AffineSamplingRatio, double, RegistrationHelper );
+
+  tubeWrapSetMacro( AffineTargetError, double, RegistrationHelper );
+  tubeWrapGetConstMacro( AffineTargetError, double, RegistrationHelper );
+
+  tubeWrapSetMacro( AffineMaxIterations, unsigned int, RegistrationHelper );
+  tubeWrapGetConstMacro( AffineMaxIterations, unsigned int, RegistrationHelper );
+
+  tubeWrapSetMacro( AffineMetricMethodEnum, MetricMethodEnumType, RegistrationHelper );
+  tubeWrapGetConstMacro( AffineMetricMethodEnum, MetricMethodEnumType,
+                         RegistrationHelper );
+
+  tubeWrapSetMacro( AffineInterpolationMethodEnum, InterpolationMethodEnumType,
+                    RegistrationHelper );
+  tubeWrapGetConstMacro( AffineInterpolationMethodEnum, InterpolationMethodEnumType,
+                         RegistrationHelper );
+
+  tubeWrapGetConstObjectMacro( AffineTransform, AffineTransformType,
+                               RegistrationHelper );
+  tubeWrapGetMacro( AffineMetricValue, double, RegistrationHelper );
+
+  //
+  // BSpline Parameters
+  //
+  tubeWrapSetMacro( BSplineSamplingRatio, double, RegistrationHelper );
+  tubeWrapGetConstMacro( BSplineSamplingRatio, double, RegistrationHelper );
+
+  tubeWrapSetMacro( BSplineTargetError, double, RegistrationHelper );
+  tubeWrapGetConstMacro( BSplineTargetError, double, RegistrationHelper );
+
+  tubeWrapSetMacro( BSplineMaxIterations, unsigned int, RegistrationHelper );
+  tubeWrapGetConstMacro( BSplineMaxIterations, unsigned int, RegistrationHelper );
+
+  tubeWrapSetMacro( BSplineControlPointPixelSpacing, double, RegistrationHelper );
+  tubeWrapGetConstMacro( BSplineControlPointPixelSpacing, double, RegistrationHelper );
+
+  tubeWrapSetMacro( BSplineMetricMethodEnum, MetricMethodEnumType, RegistrationHelper );
+  tubeWrapGetConstMacro( BSplineMetricMethodEnum, MetricMethodEnumType,
+                         RegistrationHelper );
+
+  tubeWrapSetMacro( BSplineInterpolationMethodEnum, InterpolationMethodEnumType,
+                    RegistrationHelper );
+  tubeWrapGetConstMacro( BSplineInterpolationMethodEnum, InterpolationMethodEnumType,
+                         RegistrationHelper );
+
+  tubeWrapGetConstObjectMacro( BSplineTransform, BSplineTransformType,
+                               RegistrationHelper );
+  tubeWrapGetMacro( BSplineMetricValue, double, RegistrationHelper );
+
+protected:
+  ImageToImageRegistrationHelper( void );
+  ~ImageToImageRegistrationHelper() {}
+
+  void PrintSelfHelper( std::ostream & os, itk::Indent indent,
+    const std::string & basename, MetricMethodEnumType metric,
+    InterpolationMethodEnumType interpolation ) const;
+  void PrintSelf( std::ostream & os, itk::Indent indent ) const;
+
+private:
+  /** itkImageToImageRegistrationHelperFilter parameters **/
+  ImageToImageRegistrationHelper(const Self &);
+  void operator=(const Self &);
+
+
+  typename FilterType::Pointer m_RegistrationHelper;
+
+};
+} // End namespace tube
+
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "tubeImageToImageRegistrationHelper.hxx"
+#endif
+
+#endif // End !defined( __tubeImageToImageRegistrationHelper_h )

--- a/ITKModules/TubeTKITK/include/tubeImageToImageRegistrationHelper.hxx
+++ b/ITKModules/TubeTKITK/include/tubeImageToImageRegistrationHelper.hxx
@@ -1,0 +1,508 @@
+/*=========================================================================
+
+Library:   TubeTK
+
+Copyright 2010 Kitware Inc. 28 Corporate Drive,
+Clifton Park, NY, 12065, USA.
+
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=========================================================================*/
+#ifndef __tubeImageToImageRegistrationHelper_hxx
+#define __tubeImageToImageRegistrationHelper_hxx
+
+#include "tubeImageToImageRegistrationHelper.h"
+
+namespace tube {
+
+/**
+ *
+ */
+template< class TImage, class TTransformPrecisionType >
+ImageToImageRegistrationHelper<TImage,TTransformPrecisionType>
+::ImageToImageRegistrationHelper( void )
+{
+  m_RegistrationHelper = FilterType::New();
+}
+
+/**
+ *
+ */
+template< class TImage, class TTransformPrecisionType >
+void
+ImageToImageRegistrationHelper<TImage,TTransformPrecisionType>
+::SetRegionOfInterest( const PointType & point1, const PointType & point2 )
+{
+  m_RegistrationHelper->SetRegionOfInterest(point1,point2);
+}
+
+/**
+ *
+ */
+template< class TImage, class TTransformPrecisionType >
+void
+ImageToImageRegistrationHelper<TImage,TTransformPrecisionType>
+::SetRegionOfInterest( const std::vector<float> & points )
+{
+  m_RegistrationHelper->SetRegionOfInterest(points);
+}
+
+/**
+ *
+ */
+template< class TImage, class TTransformPrecisionType >
+typename ImageToImageRegistrationHelper<TImage,TTransformPrecisionType>
+::ImageType::ConstPointer
+ImageToImageRegistrationHelper<TImage,TTransformPrecisionType>
+::ResampleImage(
+    InterpolationMethodEnumType interp, const TImage * movingImage,
+    const MatrixTransformType * matrixTransform,
+    const BSplineTransformType * bsplineTransform,
+    PixelType defaultPixelValue)
+{
+  m_RegistrationHelper->ResampleImage( interp, movingImage,
+                       matrixTransform, bsplineTransform, defaultPixelValue );
+}
+
+/**
+ *
+ */
+template< class TImage, class TTransformPrecisionType >
+typename ImageToImageRegistrationHelper<TImage,TTransformPrecisionType>
+::ImageType::ConstPointer
+ImageToImageRegistrationHelper<TImage,TTransformPrecisionType>
+::GetFinalMovingImage(InterpolationMethodEnumType interp)
+{
+  m_RegistrationHelper->GetFinalMovingImage(interp);
+}
+
+/**
+ *
+ */
+template< class TImage, class TTransformPrecisionType >
+void
+ImageToImageRegistrationHelper<TImage,TTransformPrecisionType>
+::SetFixedLandmarks( const LandmarkVectorType & fixedLandmarks )
+{
+  m_RegistrationHelper->SetFixedLandmarks(fixedLandmarks);
+  this-> Modified();
+}
+
+/**
+ *
+ */
+template< class TImage, class TTransformPrecisionType >
+void
+ImageToImageRegistrationHelper<TImage,TTransformPrecisionType>
+::SetMovingLandmarks( const LandmarkVectorType & movingLandmarks )
+{
+  m_RegistrationHelper->SetMovingLandmarks(movingLandmarks);
+  this-> Modified();
+}
+
+/**
+ *
+ */
+template< class TImage, class TTransformPrecisionType >
+void
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
+::SetLoadedMatrixTransform( const MatrixTransformType & tfm )
+{
+  m_RegistrationHelper->SetLoadedMatrixTransform(tfm);
+  this-> Modified();
+}
+
+/**
+ *
+ */
+template< class TImage, class TTransformPrecisionType >
+void
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
+::SetLoadedBSplineTransform( const BSplineTransformType & tfm )
+{
+  m_RegistrationHelper->SetLoadedBSplineTransform(tfm);
+  this-> Modified();
+}
+
+/**
+ *
+ */
+template <class TImage, class TTransformPrecisionType>
+void
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
+::PrintSelfHelper( std::ostream & os, itk::Indent indent,
+                   const std::string & basename,
+                   MetricMethodEnumType metric,
+                   InterpolationMethodEnumType interpolation ) const
+{
+  switch( metric )
+    {
+    case OptimizedRegistrationMethodType::MATTES_MI_METRIC:
+      os << indent << basename << " Metric Method = MATTES_MI_METRIC"
+        << std::endl;
+      break;
+    case OptimizedRegistrationMethodType::NORMALIZED_CORRELATION_METRIC:
+      os << indent << basename
+        << " Metric Method = CROSS_CORRELATION_METRIC" << std::endl;
+      break;
+    case OptimizedRegistrationMethodType::MEAN_SQUARED_ERROR_METRIC:
+      os << indent << basename
+        << " Metric Method = MEAN_SQUARED_ERROR_METRIC" << std::endl;
+      break;
+    default:
+      os << indent << basename << " Metric Method = UNKNOWN" << std::endl;
+      break;
+    }
+  os << indent << std::endl;
+
+  switch( interpolation )
+    {
+    case OptimizedRegistrationMethodType::NEAREST_NEIGHBOR_INTERPOLATION:
+      os << indent << basename
+        << " Interpolation Method = NEAREST_NEIGHBOR_INTERPOLATION"
+        << std::endl;
+      break;
+    case OptimizedRegistrationMethodType::LINEAR_INTERPOLATION:
+      os << indent << basename
+        << " Interpolation Method = LINEAR_INTERPOLATION" << std::endl;
+      break;
+    case OptimizedRegistrationMethodType::BSPLINE_INTERPOLATION:
+      os << indent << basename
+        << " Interpolation Method = BSPLINE_INTERPOLATION" << std::endl;
+      break;
+    case OptimizedRegistrationMethodType::SINC_INTERPOLATION:
+      os << indent << basename
+        << " Interpolation Method = SINC_INTERPOLATION" << std::endl;
+      break;
+    default:
+      os << indent << basename
+        << " Interpolation Method = UNKNOWN" << std::endl;
+      break;
+    }
+}
+
+/**
+ *
+ */
+template <class TImage, class TTransformPrecisionType>
+void
+ImageToImageRegistrationHelper<TImage, TTransformPrecisionType>
+::PrintSelf( std::ostream & os, itk::Indent indent ) const
+{
+  Superclass::PrintSelf( os, indent );
+
+  if( m_RegistrationHelper->GetFixedImage() )
+    {
+    os << indent << "Fixed Image = "
+       << m_RegistrationHelper->GetFixedImage() << std::endl;
+    }
+  if( m_RegistrationHelper->GetMovingImage() )
+    {
+    os << indent << "Moving Image = "
+       << m_RegistrationHelper->GetMovingImage() << std::endl;
+    }
+  os << indent << std::endl;
+  os << indent << "Use region of interest = "
+     << m_RegistrationHelper->GetUseRegionOfInterest() << std::endl;
+  os << indent << "Region of interest point1 = "
+     << m_RegistrationHelper->GetRegionOfInterestPoint1()
+     << std::endl;
+  os << indent << "Region of interest point2 = "
+     << m_RegistrationHelper->GetRegionOfInterestPoint2()
+     << std::endl;
+  os << indent << std::endl;
+  os << indent << "Use Fixed Image Mask Object = "
+     << m_RegistrationHelper->GetUseFixedImageMaskObject()
+     << std::endl;
+  os << indent << std::endl;
+  if( m_RegistrationHelper->GetFixedImageMaskObject() )
+    {
+    os << indent << "Fixed Image Mask Object = "
+       << m_RegistrationHelper->GetFixedImageMaskObject() << std::endl;
+    }
+  os << indent << "Use Moving Image Mask Object = "
+     << m_RegistrationHelper->GetUseMovingImageMaskObject()
+     << std::endl;
+  os << indent << std::endl;
+  if( m_RegistrationHelper->GetMovingImageMaskObject() )
+    {
+    os << indent << "Moving Image Mask Object = "
+      << m_RegistrationHelper->GetMovingImageMaskObject() << std::endl;
+    }
+  os << indent << std::endl;
+  os << indent << "Random Number Seed = "
+     << m_RegistrationHelper->GetRandomNumberSeed()
+     << std::endl;
+  os << indent << std::endl;
+  os << indent << "Enable Loaded Registration = "
+     << m_RegistrationHelper->GetEnableLoadedRegistration()
+     << std::endl;
+  os << indent << "Enable Initial Registration = "
+     << m_RegistrationHelper->GetEnableInitialRegistration()
+     << std::endl;
+  os << indent << "Enable Rigid Registration = "
+     << m_RegistrationHelper->GetEnableRigidRegistration()
+     << std::endl;
+  os << indent << "Enable Affine Registration = "
+     << m_RegistrationHelper->GetEnableAffineRegistration()
+     << std::endl;
+  os << indent << "Enable BSpline Registration = "
+     << m_RegistrationHelper->GetEnableBSplineRegistration()
+     << std::endl;
+  os << indent << std::endl;
+  os << indent << "Expected Offset (in Pixels) Magnitude = "
+     << m_RegistrationHelper->GetExpectedOffsetPixelMagnitude()
+     << std::endl;
+  os << indent << "Expected Rotation Magnitude = "
+     << m_RegistrationHelper->GetExpectedRotationMagnitude()
+     << std::endl;
+  os << indent << "Expected Scale Magnitude = "
+     << m_RegistrationHelper->GetExpectedScaleMagnitude()
+     << std::endl;
+  os << indent << "Expected Skew Magnitude = "
+     << m_RegistrationHelper->GetExpectedSkewMagnitude()
+     << std::endl;
+  os << indent << std::endl;
+  os << indent << "Completed Initialization = "
+     << m_RegistrationHelper->GetCompletedInitialization()
+     << std::endl;
+  os << indent << "Completed Resampling = "
+     << m_RegistrationHelper->GetCompletedResampling()
+     << std::endl;
+  os << indent << std::endl;
+  os << indent << "Rigid Metric Value = "
+     << m_RegistrationHelper->GetRigidMetricValue()
+     << std::endl;
+  os << indent << "Affine Metric Value = "
+     << m_RegistrationHelper->GetAffineMetricValue()
+     << std::endl;
+  os << indent << "BSpline Metric Value = "
+     << m_RegistrationHelper->GetBSplineMetricValue()
+     << std::endl;
+  os << indent << "Final Metric Value = "
+     << m_RegistrationHelper->GetFinalMetricValue()
+     << std::endl;
+  os << indent << std::endl;
+  os << indent << "Report Progress = "
+     << m_RegistrationHelper->GetReportProgress() << std::endl;
+  os << indent << std::endl;
+  if( m_RegistrationHelper->GetCurrentMovingImage() )
+    {
+    os << indent << "Current Moving Image = "
+       << m_RegistrationHelper->GetCurrentMovingImage()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Current Moving Image = NULL" << std::endl;
+    }
+  if( m_RegistrationHelper->GetCurrentMatrixTransform() )
+    {
+    os << indent << "Current Matrix Transform = "
+       << m_RegistrationHelper->GetCurrentMatrixTransform()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Current Matrix Transform = NULL" << std::endl;
+    }
+  if( m_RegistrationHelper->GetCurrentBSplineTransform() )
+    {
+    os << indent << "Current BSpline Transform = "
+       << m_RegistrationHelper->GetCurrentBSplineTransform()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Current BSpline Transform = NULL" << std::endl;
+    }
+  os << indent << std::endl;
+  if( m_RegistrationHelper->GetLoadedTransformResampledImage() )
+    {
+    os << indent << "Loaded Transform Resampled Image = "
+       << m_RegistrationHelper->GetLoadedTransformResampledImage()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Loaded Transform Resampled Image = NULL" << std::endl;
+    }
+  if( m_RegistrationHelper->GetMatrixTransformResampledImage() )
+    {
+    os << indent << "Matrix Transform Resampled Image = "
+       << m_RegistrationHelper->GetMatrixTransformResampledImage()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Matrix Transform Resampled Image = NULL" << std::endl;
+    }
+  if( m_RegistrationHelper->GetBSplineTransformResampledImage() )
+    {
+    os << indent << "BSpline Transform Resampled Image = "
+       << m_RegistrationHelper->GetBSplineTransformResampledImage()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "BSpline Transform Resampled Image = NULL"
+       << std::endl;
+    }
+  os << indent << std::endl;
+  if( m_RegistrationHelper->GetLoadedMatrixTransform() )
+    {
+    os << indent << "Loaded Matrix Transform = "
+       << m_RegistrationHelper->GetLoadedMatrixTransform()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Loaded Matrix Transform = NULL" << std::endl;
+    }
+  if( m_RegistrationHelper->GetLoadedBSplineTransform() )
+    {
+    os << indent << "Loaded BSpline Transform = "
+       << m_RegistrationHelper->GetLoadedBSplineTransform()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Loaded BSpline Transform = NULL" << std::endl;
+    }
+  os << indent << std::endl;
+
+  switch( m_RegistrationHelper->GetInitialMethodEnum() )
+    {
+    case FilterType::INIT_WITH_NONE:
+      os << indent << "Initial Registration Enum = INIT_WITH_NONE"
+         << std::endl;
+      break;
+    case FilterType::INIT_WITH_CURRENT_RESULTS:
+      os << indent
+         << "Initial Registration Enum = INIT_WITH_CURRENT_RESULTS"
+         << std::endl;
+      break;
+    case FilterType::INIT_WITH_IMAGE_CENTERS:
+      os << indent
+         << "Initial Registration Enum = INIT_WITH_IMAGE_CENTERS"
+         << std::endl;
+      break;
+    case FilterType::INIT_WITH_CENTERS_OF_MASS:
+      os << indent
+         << "Initial Registration Enum = INIT_WITH_CENTERS_OF_MASS"
+         << std::endl;
+      break;
+    case FilterType::INIT_WITH_SECOND_MOMENTS:
+      os << indent
+         << "Initial Registration Enum = INIT_WITH_SECOND_MOMENTS"
+         << std::endl;
+      break;
+    default:
+      os << indent << "Initial Registration Enum = UNKNOWN" << std::endl;
+      break;
+    }
+  if( m_RegistrationHelper->GetInitialTransform() )
+    {
+    os << indent << "Initial Transform = "
+       << m_RegistrationHelper->GetInitialTransform()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Initial Transform = NULL" << std::endl;
+    }
+  os << indent << std::endl;
+  os << indent << "Rigid Sampling Ratio = "
+     << m_RegistrationHelper->GetRigidSamplingRatio()
+     << std::endl;
+  os << indent << "Rigid Target Error = "
+     << m_RegistrationHelper->GetRigidTargetError()
+     << std::endl;
+  os << indent << "Rigid Max Iterations = "
+     << m_RegistrationHelper->GetRigidMaxIterations()
+     << std::endl;
+  PrintSelfHelper( os, indent, "Rigid",
+                   m_RegistrationHelper->GetRigidMetricMethodEnum(),
+            m_RegistrationHelper->GetRigidInterpolationMethodEnum() );
+  os << indent << std::endl;
+  if( m_RegistrationHelper->GetRigidTransform() )
+    {
+    os << indent << "Rigid Transform = "
+       << m_RegistrationHelper->GetRigidTransform()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Rigid Transform = NULL" << std::endl;
+    }
+  os << indent << std::endl;
+  os << indent << "Affine Sampling Ratio = "
+     << m_RegistrationHelper->GetAffineSamplingRatio()
+     << std::endl;
+  os << indent << "Affine Target Error = "
+     << m_RegistrationHelper->GetAffineTargetError()
+     << std::endl;
+  os << indent << "Affine Max Iterations = "
+     << m_RegistrationHelper->GetAffineMaxIterations()
+     << std::endl;
+  PrintSelfHelper( os, indent, "Affine",
+                   m_RegistrationHelper->GetAffineMetricMethodEnum(),
+            m_RegistrationHelper->GetAffineInterpolationMethodEnum() );
+  os << indent << std::endl;
+  if( m_RegistrationHelper->GetAffineTransform() )
+    {
+    os << indent << "Affine Transform = "
+       << m_RegistrationHelper->GetAffineTransform()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "Affine Transform = NULL" << std::endl;
+    }
+  os << indent << std::endl;
+  os << indent << "BSpline Sampling Ratio = "
+     << m_RegistrationHelper->GetBSplineSamplingRatio()
+     << std::endl;
+  os << indent << "BSpline Target Error = "
+     << m_RegistrationHelper->GetBSplineTargetError()
+     << std::endl;
+  os << indent << "BSpline Max Iterations = "
+     << m_RegistrationHelper->GetBSplineMaxIterations()
+     << std::endl;
+  os << indent << "BSpline Control Point Pixel Spacing = "
+     << m_RegistrationHelper->GetBSplineControlPointPixelSpacing()
+     << std::endl;
+  PrintSelfHelper( os, indent, "BSpline",
+                   m_RegistrationHelper->GetBSplineMetricMethodEnum(),
+           m_RegistrationHelper->GetBSplineInterpolationMethodEnum() );
+  os << indent << std::endl;
+  if( m_RegistrationHelper->GetBSplineTransform() )
+    {
+    os << indent << "BSpline Transform = "
+       << m_RegistrationHelper->GetBSplineTransform()
+       << std::endl;
+    }
+  else
+    {
+    os << indent << "BSpline Transform = NULL" << std::endl;
+    }
+  os << indent << std::endl;
+
+}
+
+
+} // end namespace tube
+
+#endif

--- a/ITKModules/TubeTKITK/include/tubeWrappingMacros.h
+++ b/ITKModules/TubeTKITK/include/tubeWrappingMacros.h
@@ -37,6 +37,22 @@ limitations under the License.
     return this->m_##wrap_filter_object_name->Get##name();        \
     }
 
+#define tubeWrapBooleanMacro(name,wrap_filter_object_name) \
+  void name##On ()                                         \
+    {                                                      \
+    this->m_##wrap_filter_object_name->Set##name(true);    \
+    }                                                      \
+  void name##Off ()                                        \
+    {                                                      \
+    this->m_##wrap_filter_object_name->Set##name(false);   \
+    }
+
+#define tubeWrapGetConstMacro(name, type, wrap_filter_object_name)   \
+  type Get##name () const                                            \
+    {                                                                \
+    return this->m_##wrap_filter_object_name->Get##name();           \
+    }
+
 /** Get pointer to input of object type. */
 #define tubeWrapGetObjectMacro( name, type, wrap_filter_object_name )    \
   type * Get##name( void )                                               \
@@ -54,6 +70,17 @@ limitations under the License.
 /** Set input of fundamental type */
 #define tubeWrapSetMacro( name, type, wrap_filter_object_name )   \
   void Set##name( const type value )                              \
+    {                                                             \
+    if( this->m_##wrap_filter_object_name->Get##name() != value ) \
+      {                                                           \
+      this->m_##wrap_filter_object_name->Set##name( value );      \
+      this->Modified();                                           \
+      }                                                           \
+    }
+
+/** Set reference input of fundamental type */
+#define tubeWrapSetConstReferenceMacro( name, type, wrap_filter_object_name )   \
+  void Set##name( const type & value )                              \
     {                                                             \
     if( this->m_##wrap_filter_object_name->Get##name() != value ) \
       {                                                           \

--- a/ITKModules/TubeTKITK/tubetk-depends.cmake
+++ b/ITKModules/TubeTKITK/tubetk-depends.cmake
@@ -17,7 +17,9 @@ set( TubeTKITK_DEPENDS
   Common
   Numerics
   Filtering
-  Segmentation  )
+  Segmentation
+  Registration
+  )
 
 set( TubeTKITK_LIBRARIES )
 foreach( component ${TubeTKITK_DEPENDS} )

--- a/ITKModules/TubeTKITK/wrapping/tubeImageToImageRegistrationHelper.wrap
+++ b/ITKModules/TubeTKITK/wrapping/tubeImageToImageRegistrationHelper.wrap
@@ -1,0 +1,10 @@
+itk_wrap_include( tubeImageToImageRegistrationHelper.h )
+itk_wrap_include( itkImage.h )
+
+itk_wrap_named_class("tube::ImageToImageRegistrationHelper" tubeImageToImageRegistrationHelper POINTER)
+ foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_SCALAR})
+      itk_wrap_template("I${ITKM_${t}}${d}"  "itk::Image<${ITKT_${t}}, ${d}>")
+    endforeach()
+ endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
Creation of a shadow class tubeImageToImageRegistrationHelper
to wrap itktubeImageToImageRegistrationHelper in Python, and update
MergeAdjacentImages and RegisterImages to use the shadow class.
