### PR TITLE
Separate input and output directories in SegmentVesselsUsingNeuralNetworks

### DIFF
--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
@@ -487,7 +487,7 @@ def createLmdb(name, patchesDir, patchListFile, lmdbDir):
 def createTrainTestLmdb():
     """Create LMBD instances for the training and testing data.  For
     training and testing, take the patches created by
-    createTrainTestPatches and create LMDB instances in the Caffe
+    createTrainTestPatches and create LMDB instances in the hard drive
     project directory titled Net_TrainData and Net_ValData,
     respectively.
 
@@ -497,11 +497,11 @@ def createTrainTestLmdb():
 
     # create training lmdb
     createLmdb('training', os.path.join(hardDrive_proj_root, 'training', 'patches/'),
-               'train.txt', os.path.join(caffe_proj_root, "Net_TrainData"))
+               'train.txt', os.path.join(hardDrive_proj_root, "Net_TrainData"))
 
     # create testing lmdb
     createLmdb('testing', os.path.join(hardDrive_proj_root, 'testing', 'patches/'),
-               'val.txt', os.path.join(caffe_proj_root, "Net_ValData"))
+               'val.txt', os.path.join(hardDrive_proj_root, "Net_ValData"))
 
 
 def printSectionHeader(title):

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
@@ -480,9 +480,8 @@ def createLmdb(name, patchesDir, patchListFile, lmdbDir):
 def createTrainTestLmdb():
     """Create LMBD instances for the training and testing data.  For
     training and testing, take the patches created by
-    createTrainTestPatches and create LMDB instances in the hard drive
-    project directory titled Net_TrainData and Net_ValData,
-    respectively.
+    createTrainTestPatches and create LMDB instances in the output
+    directory titled Net_TrainData and Net_ValData, respectively.
 
     """
 

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
@@ -31,12 +31,8 @@ import itk
 script_params = json.load(open('params.json'))
 
 caffe_root = script_params['CAFFE_SRC_ROOT']
-hardDrive_proj_root = script_params['OUTPUT_DATA_ROOT']
-caffe_proj_root = script_params['INPUT_DATA_ROOT']
-
-# Where the input data is to be found, to be conceptually
-# distinguished from its location in the caffe root directory
-input_image_root = caffe_proj_root
+output_data_root = script_params['OUTPUT_DATA_ROOT']
+input_data_root = script_params['INPUT_DATA_ROOT']
 
 # Create segmentation mask from tre file
 def createExpertSegmentationMask(inputImageFile, treFile, outputExpertSegFile):
@@ -141,19 +137,19 @@ def createZMIPSlabs(name, inputDir, outputDir):
 # create z-mip slabs
 def createControlTumorZMIPSlabs():
     """Create slabs from the directories Controls and LargeTumor in
-    input_image_root via createZMIPSlabs and put the results in
+    input_data_root via createZMIPSlabs and put the results in
     controls and tumors subdirectories, respectively, of
-    hardDrive_proj_root.
+    output_data_root.
 
     """
 
     # Input data directories where mha/mhd and associated tre files are located
-    controlInputDir = os.path.join(input_image_root, "Controls")
-    tumorInputDir = os.path.join(input_image_root, "LargeTumor")
+    controlInputDir = os.path.join(input_data_root, "Controls")
+    tumorInputDir = os.path.join(input_data_root, "LargeTumor")
 
     # Output data directories
-    controlOutputDir = os.path.join(hardDrive_proj_root, "controls")
-    tumorOutputDir = os.path.join(hardDrive_proj_root, "tumors")
+    controlOutputDir = os.path.join(output_data_root, "controls")
+    tumorOutputDir = os.path.join(output_data_root, "tumors")
 
     # Process control files
     createZMIPSlabs('control', controlInputDir, controlOutputDir)
@@ -282,22 +278,22 @@ def splitData(name, inputDir, outputDir, trainOutputDir, testOutputDir):
 # assign control and tumor volumes equally to training and testing
 def splitControlTumorData():
     """Split the data created from the images in the directories Controls
-    and LargeTumor in input_image_root via splitData and put the
+    and LargeTumor in input_data_root via splitData and put the
     results in training and testing subdirectories of
-    hardDrive_proj_root.
+    output_data_root.
 
     """
 
     # Input data directories
-    controlInputDir = os.path.join(input_image_root, "Controls")
-    tumorInputDir = os.path.join(input_image_root, "LargeTumor")
+    controlInputDir = os.path.join(input_data_root, "Controls")
+    tumorInputDir = os.path.join(input_data_root, "LargeTumor")
 
     # Output data directories
-    controlOutputDir = os.path.join(hardDrive_proj_root, "controls")
-    tumorOutputDir = os.path.join(hardDrive_proj_root, "tumors")
+    controlOutputDir = os.path.join(output_data_root, "controls")
+    tumorOutputDir = os.path.join(output_data_root, "tumors")
 
-    trainOutputDir = os.path.join(hardDrive_proj_root, "training")
-    testOutputDir = os.path.join(hardDrive_proj_root, "testing")
+    trainOutputDir = os.path.join(output_data_root, "training")
+    testOutputDir = os.path.join(output_data_root, "testing")
 
     # Sanity checks
     utils.ensureDirectoryExists(trainOutputDir)
@@ -452,11 +448,11 @@ def createTrainTestPatches():
     """
 
     # create training patches
-    createPatches('training', dataDir=os.path.join(hardDrive_proj_root, "training"),
+    createPatches('training', dataDir=os.path.join(output_data_root, "training"),
                   patchListFile="train.txt")
 
     # create testing patches
-    createPatches('testing', dataDir=os.path.join(hardDrive_proj_root, "testing"),
+    createPatches('testing', dataDir=os.path.join(output_data_root, "testing"),
                   patchListFile="val.txt")
 
 
@@ -493,12 +489,12 @@ def createTrainTestLmdb():
     printSectionHeader('Creating LMDBs for train and test data')
 
     # create training lmdb
-    createLmdb('training', os.path.join(hardDrive_proj_root, 'training', 'patches/'),
-               'train.txt', os.path.join(hardDrive_proj_root, "Net_TrainData"))
+    createLmdb('training', os.path.join(output_data_root, 'training', 'patches/'),
+               'train.txt', os.path.join(output_data_root, "Net_TrainData"))
 
     # create testing lmdb
-    createLmdb('testing', os.path.join(hardDrive_proj_root, 'testing', 'patches/'),
-               'val.txt', os.path.join(hardDrive_proj_root, "Net_ValData"))
+    createLmdb('testing', os.path.join(output_data_root, 'testing', 'patches/'),
+               'val.txt', os.path.join(output_data_root, "Net_ValData"))
 
 
 def printSectionHeader(title):

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
@@ -31,11 +31,8 @@ import itk
 script_params = json.load(open('params.json'))
 
 caffe_root = script_params['CAFFE_SRC_ROOT']
-hardDrive_root = script_params['CNN_DATA_ROOT']
-proj_rel_path = script_params['PROJECT_REL_PATH']
-
-caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
-hardDrive_proj_root = os.path.join(hardDrive_root, proj_rel_path)
+hardDrive_proj_root = script_params['OUTPUT_DATA_ROOT']
+caffe_proj_root = script_params['INPUT_DATA_ROOT']
 
 # Where the input data is to be found, to be conceptually
 # distinguished from its location in the caffe root directory

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
@@ -28,10 +28,10 @@ import itk
 # Define paths
 script_params = json.load(open('params.json'))
 caffe_root = script_params['CAFFE_SRC_ROOT']
-hardDrive_proj_root = script_params['OUTPUT_DATA_ROOT']
-caffe_proj_root = script_params['INPUT_DATA_ROOT']
+output_data_root = script_params['OUTPUT_DATA_ROOT']
+input_data_root = script_params['INPUT_DATA_ROOT']
 
-testDataDir = os.path.join(hardDrive_proj_root, "testing")
+testDataDir = os.path.join(output_data_root, "testing")
 
 # import caffe
 sys.path.insert(0, os.path.join(caffe_root, 'python'))
@@ -300,7 +300,7 @@ def segmentTubes(inputImageName, vascularModelFile, outputDir,
 def run():
 
     # set output directory
-    outputDir = os.path.join(hardDrive_proj_root, "testing", "cnn")
+    outputDir = os.path.join(output_data_root, "testing", "cnn")
 
     utils.ensureDirectoryExists(outputDir)
 
@@ -308,7 +308,7 @@ def run():
 
     # Model weights
     caffeModelWeights = os.path.join(
-        hardDrive_proj_root, "NetProto", "net_best.caffemodel")
+        output_data_root, "NetProto", "net_best.caffemodel")
 
     if os.path.isfile(caffeModelWeights):
         print("Caffe model weights " + caffeModelWeights + " found.")
@@ -319,7 +319,7 @@ def run():
 
     # Model definition
     caffeModelDef = os.path.join(
-        hardDrive_proj_root, "NetProto", "net_deploy.prototxt")
+        output_data_root, "NetProto", "net_deploy.prototxt")
 
     if os.path.isfile(caffeModelDef):
         print("Caffe model definition " + caffeModelDef + " found.")
@@ -370,7 +370,7 @@ def run():
         reconstructSegVolume(testAnimal, outputDir)
 
         # segment tubes using ridge traversal
-        vascularModelFile = os.path.join(caffe_proj_root, 'vascularModel.mtp')
+        vascularModelFile = os.path.join(input_data_root, 'vascularModel.mtp')
 
         segmentTubes(testAnimal, vascularModelFile, outputDir,
                      script_params['VESSEL_SEED_PROBABILITY'],

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
@@ -28,11 +28,8 @@ import itk
 # Define paths
 script_params = json.load(open('params.json'))
 caffe_root = script_params['CAFFE_SRC_ROOT']
-hardDrive_root = script_params['CNN_DATA_ROOT']
-proj_rel_path = script_params['PROJECT_REL_PATH']
-
-caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
-hardDrive_proj_root = os.path.join(hardDrive_root, proj_rel_path)
+hardDrive_proj_root = script_params['OUTPUT_DATA_ROOT']
+caffe_proj_root = script_params['INPUT_DATA_ROOT']
 
 testDataDir = os.path.join(hardDrive_proj_root, "testing")
 

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
@@ -311,7 +311,7 @@ def run():
 
     # Model weights
     caffeModelWeights = os.path.join(
-        caffe_proj_root, "NetProto", "net_best.caffemodel")
+        hardDrive_proj_root, "NetProto", "net_best.caffemodel")
 
     if os.path.isfile(caffeModelWeights):
         print("Caffe model weights " + caffeModelWeights + " found.")
@@ -322,7 +322,7 @@ def run():
 
     # Model definition
     caffeModelDef = os.path.join(
-        caffe_proj_root, "NetProto", "net_deploy.prototxt")
+        hardDrive_proj_root, "NetProto", "net_deploy.prototxt")
 
     if os.path.isfile(caffeModelDef):
         print("Caffe model definition " + caffeModelDef + " found.")

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -21,8 +21,8 @@ import utils
 # Define paths
 script_params = json.load(open('params.json'))
 caffe_root = str(script_params['CAFFE_SRC_ROOT'])
-hardDrive_proj_root = str(script_params['OUTPUT_DATA_ROOT'])
-caffe_proj_root = script_params['INPUT_DATA_ROOT']
+output_data_root = str(script_params['OUTPUT_DATA_ROOT'])
+input_data_root = script_params['INPUT_DATA_ROOT']
 
 # import caffe
 sys.path.insert(0, os.path.join(caffe_root, 'python'))  # Add pycaffe
@@ -32,7 +32,7 @@ from caffe.proto import caffe_pb2
 import lmdb
 
 # Define file paths
-net_proto_path = os.path.join(hardDrive_proj_root, 'NetProto')
+net_proto_path = os.path.join(output_data_root, 'NetProto')
 snapshot_prefix = os.path.join(net_proto_path, 'net')
 
 train_net_path = os.path.join(net_proto_path, 'net_train.prototxt')
@@ -193,12 +193,12 @@ def run():
 
     # Create testing and training net
     train_batch_size = script_params['TRAIN_BATCH_SIZE']
-    train_lmdb_path = os.path.join(hardDrive_proj_root, 'Net_TrainData')
+    train_lmdb_path = os.path.join(output_data_root, 'Net_TrainData')
     with open(train_net_path, 'w') as f:
         f.write(str(custom_net(train_batch_size, train_lmdb_path)))
 
     test_batch_size = script_params['TEST_BATCH_SIZE']
-    test_lmdb_path = os.path.join(hardDrive_proj_root, 'Net_ValData')
+    test_lmdb_path = os.path.join(output_data_root, 'Net_ValData')
     with open(test_net_path, 'w') as f:
         f.write(str(custom_net(test_batch_size, test_lmdb_path)))
 

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -25,6 +25,7 @@ hardDrive_root = str(script_params['CNN_DATA_ROOT'])
 proj_rel_path = script_params['PROJECT_REL_PATH']
 
 caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
+hardDrive_proj_root = os.path.join(hardDrive_root, proj_rel_path)
 
 # import caffe
 sys.path.insert(0, os.path.join(caffe_root, 'python'))  # Add pycaffe
@@ -34,7 +35,7 @@ from caffe.proto import caffe_pb2
 import lmdb
 
 # Define file paths
-net_proto_path = os.path.join(caffe_proj_root, 'NetProto')
+net_proto_path = os.path.join(hardDrive_proj_root, 'NetProto')
 snapshot_prefix = os.path.join(net_proto_path, 'net')
 
 train_net_path = os.path.join(net_proto_path, 'net_train.prototxt')
@@ -195,12 +196,12 @@ def run():
 
     # Create testing and training net
     train_batch_size = script_params['TRAIN_BATCH_SIZE']
-    train_lmdb_path = os.path.join(caffe_proj_root, 'Net_TrainData')
+    train_lmdb_path = os.path.join(hardDrive_proj_root, 'Net_TrainData')
     with open(train_net_path, 'w') as f:
         f.write(str(custom_net(train_batch_size, train_lmdb_path)))
 
     test_batch_size = script_params['TEST_BATCH_SIZE']
-    test_lmdb_path = os.path.join(caffe_proj_root, 'Net_ValData')
+    test_lmdb_path = os.path.join(hardDrive_proj_root, 'Net_ValData')
     with open(test_net_path, 'w') as f:
         f.write(str(custom_net(test_batch_size, test_lmdb_path)))
 

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -21,11 +21,8 @@ import utils
 # Define paths
 script_params = json.load(open('params.json'))
 caffe_root = str(script_params['CAFFE_SRC_ROOT'])
-hardDrive_root = str(script_params['CNN_DATA_ROOT'])
-proj_rel_path = script_params['PROJECT_REL_PATH']
-
-caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
-hardDrive_proj_root = os.path.join(hardDrive_root, proj_rel_path)
+hardDrive_proj_root = str(script_params['OUTPUT_DATA_ROOT'])
+caffe_proj_root = script_params['INPUT_DATA_ROOT']
 
 # import caffe
 sys.path.insert(0, os.path.join(caffe_root, 'python'))  # Add pycaffe

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -22,6 +22,9 @@ import utils
 script_params = json.load(open('params.json'))
 caffe_root = str(script_params['CAFFE_SRC_ROOT'])
 hardDrive_root = str(script_params['CNN_DATA_ROOT'])
+proj_rel_path = script_params['PROJECT_REL_PATH']
+
+caffe_proj_root = os.path.join(caffe_root, "data", proj_rel_path)
 
 # import caffe
 sys.path.insert(0, os.path.join(caffe_root, 'python'))  # Add pycaffe
@@ -31,8 +34,7 @@ from caffe.proto import caffe_pb2
 import lmdb
 
 # Define file paths
-net_proto_path = os.path.join(
-    caffe_root, 'data/SegmentVesselsUsingNeuralNetworks/NetProto')
+net_proto_path = os.path.join(caffe_proj_root, 'NetProto')
 snapshot_prefix = os.path.join(net_proto_path, 'net')
 
 train_net_path = os.path.join(net_proto_path, 'net_train.prototxt')
@@ -193,14 +195,12 @@ def run():
 
     # Create testing and training net
     train_batch_size = script_params['TRAIN_BATCH_SIZE']
-    train_lmdb_path = os.path.join(
-        caffe_root, 'data/SegmentVesselsUsingNeuralNetworks/Net_TrainData')
+    train_lmdb_path = os.path.join(caffe_proj_root, 'Net_TrainData')
     with open(train_net_path, 'w') as f:
         f.write(str(custom_net(train_batch_size, train_lmdb_path)))
 
     test_batch_size = script_params['TEST_BATCH_SIZE']
-    test_lmdb_path = os.path.join(
-        caffe_root, 'data/SegmentVesselsUsingNeuralNetworks/Net_ValData')
+    test_lmdb_path = os.path.join(caffe_proj_root, 'Net_ValData')
     with open(test_net_path, 'w') as f:
         f.write(str(custom_net(test_batch_size, test_lmdb_path)))
 
@@ -227,7 +227,7 @@ def run():
     # ignore this workaround for lmdb data (can't instantiate two solvers on
     # the same data)
     solver = None
-    solver = caffe.get_solver(solver_config_path)
+    solver = caffe.get_solver(str(solver_config_path))
 
     # print the structure of the network
     print '\nNumber of training samples = ', num_train_samples

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/params.json
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/params.json
@@ -1,7 +1,7 @@
 {
-    "CNN_DATA_ROOT": "/media/krs0014",
+    "OUTPUT_DATA_ROOT": "/media/krs0014/SegmentVesselsUsingNeuralNetworks",
     "CAFFE_SRC_ROOT": "/home/cdeepakroy/work/Libs/caffe",
-    "PROJECT_REL_PATH": "SegmentVesselsUsingNeuralNetworks",
+    "INPUT_DATA_ROOT": "/home/cdeepakroy/work/Libs/caffe/data/SegmentVesselsUsingNeuralNetworks",
     "PATCH_RADIUS": 32,
     "NUM_SLABS": 10,
     "SLAB_OVERLAP": 20,


### PR DESCRIPTION
The current directory setup makes it difficult to reuse input data across multiple configurations / experiments. It also requires placing the data in Caffe's source directory.

This PR puts all generated data together, leaving the input directory untouched, and lets the input directory be placed anywhere. Note that, because `PROJECT_REL_PATH` has been removed, the special case of giving the input and output directories the same name has no shortcut -- but it is no longer the only option.