### PR TITLE
Convert SegmentVesselsUsingNeuralNetworks to Keras

### DIFF
--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
@@ -334,8 +334,8 @@ def extractPatchesFromImage(rootDir, imageName, outputDir, patchListFile):
     - $rootDir/expert/$imageName_expert.png: The corresponding expert mask
 
     Output:
-    - $outputDir/0/$imageName_$i_$j.png: Negative patches
-    - $outputDir/1/$imageName_$i_$j.png: Positive patches
+    - $outputDir/0/$imageName/$i_$j.png: Negative patches
+    - $outputDir/1/$imageName/$i_$j.png: Positive patches
 
     """
 
@@ -349,12 +349,15 @@ def extractPatchesFromImage(rootDir, imageName, outputDir, patchListFile):
         psi = str(patchSetIndex)
 
         filename = os.path.join(
-            psi, imageName + "_" + str(i) + "_" + str(j) + ".png")
+            psi, imageName, str(i) + "_" + str(j) + ".png")
 
         patchListFile.write(filename + " " + psi + "\n")
 
         skimage.io.imsave(os.path.join(outputDir, filename),
                           inputImage[i - w : i + w + 1, j - w : j + w + 1])
+
+    for i in range(2):
+        utils.ensureDirectoryExists(os.path.join(outputDir, str(i), imageName))
 
     # patch/window radius
     w = script_params['PATCH_RADIUS']

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
@@ -486,22 +486,21 @@ def createTrainTestPatches():
                   patchListFile="val.txt")
 
 
-# TODO update names and docs
-def createLmdb(name, patchesDir, patchListFile, lmdbDir):
-    """Create an LMDB instance in lmdbDir from the patches in patchesDir,
-    indexed by patchListFile
+def createDB(name, patchesDir, patchListFile, dbDir):
+    """Create a database in dbDir from the patches in patchesDir, indexed
+    by patchListFile
 
     """
-    print('Creating %s lmdb ...\n' % name)
+    print('Creating %s DB ...\n' % name)
 
-    if os.path.exists(lmdbDir):
-        shutil.rmtree(lmdbDir)
+    if os.path.exists(dbDir):
+        shutil.rmtree(dbDir)
 
-    utils.ensureDirectoryExists(lmdbDir)
+    utils.ensureDirectoryExists(dbDir)
 
     patchListFile = os.path.join(patchesDir, patchListFile)
 
-    db = utils.open_sqlite3_db(lmdbDir)
+    db = utils.open_sqlite3_db(dbDir)
     db.execute('''create table "Patches" (
         "filename" text,
         "patch_index" integer,
@@ -530,24 +529,24 @@ def createLmdb(name, patchesDir, patchListFile, lmdbDir):
     db.commit()
     db.close()
 
-# create lmdb
-def createTrainTestLmdb():
-    """Create LMBD instances for the training and testing data.  For
-    training and testing, take the patches created by
-    createTrainTestPatches and create LMDB instances in the output
+def createTrainTestDB():
+    """Create databases for the training and testing data.
+
+    For training and testing, take the patches created by
+    createTrainTestPatches and create a database in the output
     directory titled Net_TrainData and Net_ValData, respectively.
 
     """
 
-    printSectionHeader('Creating LMDBs for train and test data')
+    printSectionHeader('Creating DBs for train and test data')
 
-    # create training lmdb
-    createLmdb('training', os.path.join(output_data_root, 'training', 'patches/'),
-               'train.txt', os.path.join(output_data_root, "Net_TrainData"))
+    # create training DB
+    createDB('training', os.path.join(output_data_root, 'training', 'patches/'),
+             'train.txt', os.path.join(output_data_root, "Net_TrainData"))
 
-    # create testing lmdb
-    createLmdb('testing', os.path.join(output_data_root, 'testing', 'patches/'),
-               'val.txt', os.path.join(output_data_root, "Net_ValData"))
+    # create testing DB
+    createDB('testing', os.path.join(output_data_root, 'testing', 'patches/'),
+             'val.txt', os.path.join(output_data_root, "Net_ValData"))
 
 
 def printSectionHeader(title):
@@ -569,8 +568,8 @@ def run():
     # convert train/test images to patches
     createTrainTestPatches()
 
-    # create lmdb database
-    createTrainTestLmdb()
+    # create database
+    createTrainTestDB()
 
 
 if __name__ == "__main__":

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/PrepareTrainingData.py
@@ -18,7 +18,6 @@ import sys
 
 import skimage.io
 import numpy as np
-import sqlite3
 
 import utils
 
@@ -502,7 +501,7 @@ def createLmdb(name, patchesDir, patchListFile, lmdbDir):
 
     patchListFile = os.path.join(patchesDir, patchListFile)
 
-    db = sqlite3.connect(os.path.join(lmdbDir, 'data.sqlite3'))
+    db = utils.open_sqlite3_db(lmdbDir)
     db.execute('''create table "Patches" (
         "filename" text,
         "patch_index" integer,
@@ -561,11 +560,11 @@ def printSectionHeader(title):
 def run():
 
     # create z-mip slabs
-    createControlTumorZMIPSlabs()
+    #createControlTumorZMIPSlabs()
 
     # assign control and tumor volumes equally to training and testing
     # Note: this must be called after createZMIPSlabs()
-    splitControlTumorData()
+    #splitControlTumorData()
 
     # convert train/test images to patches
     createTrainTestPatches()

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
@@ -100,11 +100,11 @@ def segmentSlab(net, input_file, output_file):
     output_image = np.zeros_like(input_image)  # Output segmented slab
     output_image_flat = np.ravel(output_image)
 
-    pw = test_batch_size - (num_patches % test_batch_size)
+    pw = -num_patches % test_batch_size
     patches = np.pad(patches, ((0, pw), (0, 0), (0, 0)), 'constant')
     patch_indices = np.pad(patch_indices, ((0, pw), (0, 0)), 'constant')
 
-    patches = np.rollaxis(np.expand_dims(patches, 3), 3, 1)
+    patches = patches[:, np.newaxis]
     print patches.shape
 
     for i in range(0, num_patches, test_batch_size):

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
@@ -112,7 +112,7 @@ def segmentSlab(net, input_file, output_file):
         cur_patches = patches[i:i + test_batch_size]
 
         # perform classification using cnn
-        prob_vessel = net.predict(cur_patches / 255., test_batch_size)[:, 1]
+        prob_vessel = net.predict(utils.scale_net_input_data(cur_patches), test_batch_size)[:, 1]
 
         if i + test_batch_size > num_patches:
 

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
@@ -51,7 +51,7 @@ def segmentSlab(net, input_file, output_file):
     fgnd_mask = input_image > th
 
     # get test_batch_size and patch_size used for cnn net
-    test_batch_size = script_params['TEST_BATCH_SIZE']
+    test_batch_size = script_params['DEPLOY_BATCH_SIZE']
     patch_size = data_shape[1]
 
     print 'Test batch shape = ', data_shape

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TestNet.py
@@ -27,23 +27,21 @@ import itk
 
 # Define paths
 script_params = json.load(open('params.json'))
-caffe_root = script_params['CAFFE_SRC_ROOT']
 output_data_root = script_params['OUTPUT_DATA_ROOT']
 input_data_root = script_params['INPUT_DATA_ROOT']
 
 testDataDir = os.path.join(output_data_root, "testing")
 
-# import caffe
-sys.path.insert(0, os.path.join(caffe_root, 'python'))
-import caffe
-
+import keras.models as M
 
 # Segment a slab
 def segmentSlab(net, input_file, output_file):
 
     print "Segmenting slab ", input_file
 
-    print net.blobs['data'].data.shape
+    data_shape = net.input_shape
+
+    print data_shape
 
     # read input slab image
     input_image = skimage.io.imread(input_file)
@@ -53,10 +51,10 @@ def segmentSlab(net, input_file, output_file):
     fgnd_mask = input_image > th
 
     # get test_batch_size and patch_size used for cnn net
-    test_batch_size = net.blobs['data'].data.shape[0]
-    patch_size = net.blobs['data'].data.shape[2]
+    test_batch_size = script_params['TEST_BATCH_SIZE']
+    patch_size = data_shape[1]
 
-    print 'Test batch shape = ', net.blobs['data'].data.shape
+    print 'Test batch shape = ', data_shape
 
     # collect all patches
     print "Extracting patches ... "
@@ -104,7 +102,7 @@ def segmentSlab(net, input_file, output_file):
     patches = np.pad(patches, ((0, pw), (0, 0), (0, 0)), 'constant')
     patch_indices = np.pad(patch_indices, ((0, pw), (0, 0)), 'constant')
 
-    patches = patches[:, np.newaxis]
+    patches = patches[..., np.newaxis]
     print patches.shape
 
     for i in range(0, num_patches, test_batch_size):
@@ -114,11 +112,7 @@ def segmentSlab(net, input_file, output_file):
         cur_patches = patches[i:i + test_batch_size]
 
         # perform classification using cnn
-        net.blobs['data'].data[...] = cur_patches
-
-        output = net.forward()
-
-        prob_vessel = output['loss'][:, 1]
+        prob_vessel = net.predict(cur_patches / 255., test_batch_size)[:, 1]
 
         if i + test_batch_size > num_patches:
 
@@ -306,43 +300,19 @@ def run():
 
     sys.stdout = utils.Logger(os.path.join(outputDir, 'net_test.log'))
 
-    # Model weights
-    caffeModelWeights = os.path.join(
-        output_data_root, "NetProto", "net_best.caffemodel")
-
-    if os.path.isfile(caffeModelWeights):
-        print("Caffe model weights " + caffeModelWeights + " found.")
-    else:
-        print('Error : Caffe model weights "' + caffeModelWeights + '" not found.\n' +
-              '  Train neural network before processing it.')
-        sys.exit(0)
-
     # Model definition
-    caffeModelDef = os.path.join(
-        output_data_root, "NetProto", "net_deploy.prototxt")
+    modelDef = os.path.join(
+        output_data_root, "NetProto", "net_best.hdf5")
 
-    if os.path.isfile(caffeModelDef):
-        print("Caffe model definition " + caffeModelDef + " found.")
+    if os.path.isfile(modelDef):
+        print("Model definition " + modelDef + " found.")
     else:
-        print('Error : Caffe model definition "' + caffeModelDef + '" not found.\n' +
+        print('Error : model definition "' + modelDef + '" not found.\n' +
               '  Train neural network before processing it.')
         sys.exit(0)
 
     # Create network
-    caffe.set_mode_gpu()
-
-    net = caffe.Net(str(caffeModelDef),  # defines the structure of the model
-                    str(caffeModelWeights),  # contains the trained weights
-                    caffe.TEST)  # use test mode (e.g., don't perform dropout)
-
-    # set the size of the input (we can skip this if we're happy
-    # with the default; we can also change it later, e.g., for different batch
-    # sizes)
-    w = script_params['PATCH_RADIUS']
-
-    net.blobs['data'].reshape(script_params['DEPLOY_BATCH_SIZE'],  # batch size
-                              1,  # 1-channel
-                              2 * w + 1, 2 * w + 1)  # image size
+    net = M.load_model(modelDef)
 
     # get list of test mha files
     testMhaFiles = glob.glob(os.path.join(

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -20,28 +20,25 @@ import utils
 
 # Define paths
 script_params = json.load(open('params.json'))
-caffe_root = str(script_params['CAFFE_SRC_ROOT'])
 output_data_root = str(script_params['OUTPUT_DATA_ROOT'])
 input_data_root = script_params['INPUT_DATA_ROOT']
 
-# import caffe
-sys.path.insert(0, os.path.join(caffe_root, 'python'))  # Add pycaffe
-import caffe
-from caffe import layers as L, params as P
-from caffe.proto import caffe_pb2
-import lmdb
+import keras
+import keras.callbacks as C
+import keras.layers as L
+import keras.models as M
+import keras.optimizers as O
+import keras.utils as U
 
 # Define file paths
 net_proto_path = os.path.join(output_data_root, 'NetProto')
-snapshot_prefix = os.path.join(net_proto_path, 'net')
-
-train_net_path = os.path.join(net_proto_path, 'net_train.prototxt')
-test_net_path = os.path.join(net_proto_path, 'net_test.prototxt')
-deploy_net_path = os.path.join(net_proto_path, 'net_deploy.prototxt')
-solver_config_path = os.path.join(net_proto_path, 'net_solver.prototxt')
+snapshot_format = os.path.join(net_proto_path, 'net').replace('{','{{').replace('}','}}') + \
+                  '_{epoch:02d}.hdf5'
 
 train_results_dir = os.path.join(net_proto_path, 'train_results')
 utils.ensureDirectoryExists(train_results_dir)
+
+patch_size = 2 * script_params['PATCH_RADIUS'] + 1
 
 # Features square plot :
 #   Plot any layer's output features with the data parameter corresponding to
@@ -79,117 +76,64 @@ def squarePlot(data):
     plt.pause(0.05)
 
 
-# Define net architecture
-def custom_net(batch_size, lmdb=None):
+# Define net architecture, returning an uncompiled model
+def custom_net():
+    # Channels go last
+    inputs = L.Input(shape=(patch_size, patch_size, 1))
 
-    # define your own net!
-    n = caffe.NetSpec()
+    # First layer set
+    x = L.Conv2D(filters=48, kernel_size=6)(inputs)
+    x = L.LeakyReLU(0.1)(x)
+    x = L.MaxPooling2D(2)(x)
 
-    # keep this data layer for all networks
-    if lmdb:
+    # Second layer set
+    x = L.Conv2D(filters=48, kernel_size=5)(x)
+    x = L.LeakyReLU(0.1)(x)
+    x = L.MaxPooling2D(2)(x)
 
-        n.data, n.label = L.Data(batch_size=batch_size, backend=P.Data.LMDB, source=lmdb,
-                                 ntop=2, transform_param=dict(scale=1. / 255))
+    # Second layer set
+    x = L.Conv2D(filters=48, kernel_size=4)(x)
+    x = L.LeakyReLU(0.1)(x)
+    x = L.MaxPooling2D(2)(x)
 
-    else:
+    # Second layer set
+    x = L.Conv2D(filters=48, kernel_size=2)(x)
+    x = L.LeakyReLU(0.1)(x)
+    x = L.MaxPooling2D(2)(x)
 
-        # deploy mode
-        patch_size = 2 * script_params['PATCH_RADIUS'] + 1
+    # Fully connected layer set
+    x = L.Flatten()(x)
+    x = L.Dense(50)(x)
+    x = L.LeakyReLU(0.1)(x)
 
-        n.data = L.Input(shape=[dict(dim=[batch_size, 1, patch_size, patch_size])],
-                         transform_param=dict(scale=1.0 / 255.0))
+    x = L.Dropout(0.5)(x)
 
-    n.conv1 = L.Convolution(n.data, kernel_size=6,
-                            num_output=48, weight_filler=dict(type='xavier'))
-    n.relu1 = L.ReLU(n.conv1, negative_slope=0.1)
-    n.pool1 = L.Pooling(n.relu1, kernel_size=2, stride=2, pool=P.Pooling.MAX)
+    # Classify
+    x = L.Dense(2)(x)
+    predictions = L.Activation('softmax')(x)
 
-    n.conv2 = L.Convolution(n.pool1, kernel_size=5,
-                            num_output=48, weight_filler=dict(type='xavier'))
-    n.relu2 = L.ReLU(n.conv2, negative_slope=0.1)
-    n.pool2 = L.Pooling(n.relu2, kernel_size=2, stride=2, pool=P.Pooling.MAX)
-
-    n.conv3 = L.Convolution(n.pool2, kernel_size=4,
-                            num_output=48, weight_filler=dict(type='xavier'))
-    n.relu3 = L.ReLU(n.conv3, negative_slope=0.1)
-    n.pool3 = L.Pooling(n.relu3, kernel_size=2, stride=2, pool=P.Pooling.MAX)
-
-    n.conv4 = L.Convolution(n.pool3, kernel_size=2,
-                            num_output=48, weight_filler=dict(type='xavier'))
-    n.relu4 = L.ReLU(n.conv4, negative_slope=0.1)
-    n.pool4 = L.Pooling(n.relu4, kernel_size=2, stride=2, pool=P.Pooling.MAX)
-
-    n.fc1 = L.InnerProduct(n.pool4, num_output=50,
-                           weight_filler=dict(type='xavier'))
-    n.relu5 = L.ReLU(n.fc1, negative_slope=0.1)
-
-    n.drop1 = L.Dropout(n.relu5, dropout_param=dict(dropout_ratio=0.5))
-
-    n.score = L.InnerProduct(n.drop1, num_output=2,
-                             weight_filler=dict(type='xavier'))
-
-    # keep this loss layer for all networks
-    if lmdb:
-
-        n.loss = L.SoftmaxWithLoss(n.score, n.label)
-
-    else:
-
-        # deploy mode
-        n.loss = L.Softmax(n.score)
-
-    return n.to_proto()
+    return M.Model(inputs=inputs, outputs=predictions)
 
 
-def custom_solver(num_train_samples, num_test_samples):
+# Configure and compile model
+def custom_solver(net):
 
-    # Define and save solver params
-    solver_params = caffe_pb2.SolverParameter()
+    net.compile(O.SGD(lr=script_params['BASE_LR'],
+                      momentum=script_params['MOMENTUM'],
+                      decay=script_params['GAMMA']),
+                'categorical_crossentropy',
+                metrics=['accuracy'])
 
-    # set solver_params type - "SGD", "Adam", and "Nesterov" etc
-    solver_params.type = script_params['SOLVER_TYPE']
 
-    # set solver params parameters
-    solver_params.base_lr = script_params['BASE_LR']
-    solver_params.momentum = script_params['MOMENTUM']
-    solver_params.weight_decay = script_params['WEIGHT_DECAY']
+def queryResultToModelArguments(result):
+    """Convert the list of (image, label) pairs from a query into a pair
+    of NumPy arrays to pass into various model functions.
 
-    solver_params.lr_policy = script_params['LR_DECAY_POLICY']
-    solver_params.gamma = script_params['GAMMA']
-    solver_params.power = script_params['POWER']
-
-    # Set a seed for reproducible experiments
-    solver_params.random_seed = 0xCAFFE
-
-    # Specify locations of the train and (maybe) test networks.
-    solver_params.train_net = train_net_path
-    solver_params.test_net.append(test_net_path)
-
-    # specify train iterations
-    # num passes through train dataset
-    num_train_epochs = script_params['NUM_TRAIN_EPOCHS']
-    train_batch_size = script_params['TRAIN_BATCH_SIZE']
-    num_train_iters_per_epoch = num_train_samples / train_batch_size
-
-    solver_params.max_iter = num_train_epochs * num_train_iters_per_epoch
-
-    # specify test interval and iterations
-    # num passes through test dataset
-    num_test_epochs = script_params['NUM_TEST_EPOCHS']
-    test_batch_size = script_params['TEST_BATCH_SIZE']
-    num_test_iters_per_epoch = num_test_samples / test_batch_size
-
-    # one pass through train dataset
-    solver_params.test_interval = num_train_iters_per_epoch
-    solver_params.test_iter.append(num_test_epochs * num_test_iters_per_epoch)
-
-    solver_params.display = solver_params.test_interval
-    solver_params.snapshot = solver_params.test_interval
-    solver_params.snapshot_prefix = snapshot_prefix
-
-    solver_params.solver_mode = caffe_pb2.SolverParameter.GPU
-
-    return solver_params
+    """
+    image_data = (np.array([np.frombuffer(im, dtype=np.uint8) for im, _ in result])
+                  .reshape((len(result), patch_size, patch_size, 1)) / 255.)
+    labels = np.array([l for _, l in result])
+    return image_data, labels
 
 
 def run():
@@ -199,43 +143,31 @@ def run():
     # Create testing and training net
     train_batch_size = script_params['TRAIN_BATCH_SIZE']
     train_lmdb_path = os.path.join(output_data_root, 'Net_TrainData')
-    with open(train_net_path, 'w') as f:
-        f.write(str(custom_net(train_batch_size, train_lmdb_path)))
 
     test_batch_size = script_params['TEST_BATCH_SIZE']
     test_lmdb_path = os.path.join(output_data_root, 'Net_ValData')
-    with open(test_net_path, 'w') as f:
-        f.write(str(custom_net(test_batch_size, test_lmdb_path)))
 
-    with open(deploy_net_path, 'w') as f:
-        f.write(str(custom_net(test_batch_size, None)))
+    net = custom_net()
+    custom_solver(net)
+
+    def get_sample_count(path):
+        db = utils.open_sqlite3_db(path)
+        retval, = db.execute('''select count(*) from "Patches"''').fetchone()
+        db.close()
+        return retval
 
     # get number of train/test samples
-    num_train_samples = lmdb.open(
-        train_lmdb_path, readonly=True).stat()['entries']
-    num_test_samples = lmdb.open(
-        test_lmdb_path, readonly=True).stat()['entries']
+    num_train_samples = get_sample_count(train_lmdb_path)
+    num_test_samples = get_sample_count(test_lmdb_path)
 
-    # Define and save solver params
-    solver_params = custom_solver(num_train_samples, num_test_samples)
-
-    with open(solver_config_path, 'w') as f:
-        f.write(str(solver_params))
-
-    # Must be called before instantiating solver due to potential
-    # Caffe bug
-    caffe.set_mode_gpu()  # Use GPU
-
-    # load the solver and create train and test nets
-    # ignore this workaround for lmdb data (can't instantiate two solvers on
-    # the same data)
-    solver = None
-    solver = caffe.get_solver(str(solver_config_path))
+    solver = net
 
     # print the structure of the network
     print '\nNumber of training samples = ', num_train_samples
     print 'Number of testing samples = ', num_test_samples
 
+    # TODO translate
+    '''
     print('\nNetwork structure ...')
     for layer_name, blob in solver.net.blobs.iteritems():
         print(layer_name + '\t' + str(blob.data.shape))
@@ -252,6 +184,7 @@ def run():
         num_params += cur_num_params
 
     print 'Total number of params : %d (%.3f MB)' % (num_params, num_params * 8.0 / 10**6)
+    '''
 
     # ask if user wants to start training
     flag_train = raw_input('start training (y/n)?')
@@ -260,11 +193,13 @@ def run():
         sys.exit(0)
 
     # solve
-
+    # TODO figure out how to translate
+    '''
     fig = {}
     for layer_name in solver.net.params.keys():
         if layer_name.startswith('conv'):
             fig[layer_name] = plt.figure()
+    '''
 
     num_train_epochs = script_params['NUM_TRAIN_EPOCHS']
     train_batch_size = script_params['TRAIN_BATCH_SIZE']
@@ -276,92 +211,48 @@ def run():
     num_test_iters_per_epoch = num_test_samples / test_batch_size
     num_test_iters = num_test_epochs * num_test_iters_per_epoch
 
-    assert(num_train_iters == solver_params.max_iter)
-    assert(num_test_iters == solver_params.test_iter[0])
-    assert(num_train_iters_per_epoch == solver_params.test_interval)
+    def data_generator(lmdb_path, batch_size):
+        """Generate batches of batch_size samples from the database at
+        lmdb_path, looping through the database repeatedly, and
+        ignoring remaining samples when the total sample count is
+        divided by batch_size.
 
-    train_loss = np.zeros(num_train_iters)
-    test_acc = np.zeros(num_train_epochs)
-    test_loss = np.zeros_like(test_acc)
+        """
+        db = utils.open_sqlite3_db(lmdb_path)
+        cursor = db.cursor()
+        while True:
+            cursor.execute('''select "image_data", "patch_index"
+                              from "Patches"''')
+            while True:
+                result = cursor.fetchmany(batch_size)
+                if len(result) < batch_size:
+                    break
+                image_data, labels = queryResultToModelArguments(result)
+                yield image_data, U.to_categorical(labels, 2)
 
-    it_train = 0
+    history = solver.fit_generator(data_generator(train_lmdb_path, train_batch_size),
+                                   steps_per_epoch=num_train_iters_per_epoch,
+                                   epochs=num_train_epochs,
+                                   callbacks=[C.ProgbarLogger('steps'),
+                                              C.ModelCheckpoint(snapshot_format)],
+                                   validation_data=data_generator(test_lmdb_path, test_batch_size),
+                                   validation_steps=num_test_iters_per_epoch).history
 
-    best_iter = -1
-    best_epoch = -1
-    best_acc = 0
+    print 'Test accuracy : ', history['val_acc']
+    print 'Test loss     : ', history['val_loss']
 
-    for ep_train in range(num_train_epochs):
+    best_epoch = np.argmax(history['val_acc'])
+    best_acc = history['val_acc'][best_epoch]
 
-        # make one pass through training data
-        t = time.time()
+    # save best model
+    print 'Best model: accuracy = %s, epoch = %s' % (best_acc, best_epoch)
 
-        mean_train_loss = 0
+    shutil.copyfile(
+        snapshot_format.format(epoch=best_epoch),
+        os.path.join(net_proto_path, 'net_best.hdf5')
+    )
 
-        for i in range(num_train_iters_per_epoch):
-
-            # make one training step
-            solver.step(1)  # SGD by Caffe
-
-            # get and store the loss
-            cur_loss = solver.net.blobs['loss'].data
-
-            train_loss[it_train] = cur_loss
-
-            mean_train_loss += cur_loss
-
-            it_train += 1
-
-        epoch_train_time = time.time() - t
-
-        mean_train_loss /= num_train_iters_per_epoch
-
-        # validate model
-        correct = 0.0
-        num_test_cases = 0.0
-        mean_test_loss = 0.0
-
-        t = time.time()
-
-        for ep_test in range(num_test_epochs):
-
-            for i in range(num_test_iters_per_epoch):
-
-                # make one validation step
-                solver.test_nets[0].forward()
-
-                # compute and store test accuracy
-                pred_labels = solver.test_nets[0].blobs['score'].data.argmax(1)
-                true_labels = solver.test_nets[0].blobs['label'].data
-                correct += np.sum(pred_labels == true_labels)
-                num_test_cases += len(pred_labels)
-
-                # compute and store test loss
-                mean_test_loss += solver.test_nets[0].blobs['loss'].data
-
-        mean_test_loss /= num_test_iters
-        cur_acc = correct / num_test_cases
-
-        test_acc[ep_train] = cur_acc
-        test_loss[ep_train] = mean_test_loss
-
-        if cur_acc > best_acc:
-
-            best_iter = it_train
-            best_epoch = ep_train
-            best_acc = cur_acc
-
-        test_time = time.time() - t
-
-        # print status
-        print 'Training epoch %s / %s ...' % (ep_train + 1, num_train_epochs)
-
-        print '\tTrain loss mean = %s' % mean_train_loss
-        print '\tNo of training iterations finished = %s' % it_train
-        print '\tEpoch training time = %s' % epoch_train_time
-
-        print "\tTest loss mean = %s, accuracy = %s" % (mean_test_loss, cur_acc)
-        print "\tTesting time = %s" % test_time
-
+    '''
         # Visualize convolutional filters at each layer
         for layer_name in solver.net.params.keys():
 
@@ -387,32 +278,14 @@ def run():
                                                             it_train)
                     )
                 )
-
-    print 'Test accuracy : ', test_acc
-    print 'Test loss     : ', test_loss
-
-    # save best model
-    print 'Best model: accuracy = %s, iter = %s, epoch = %s' % (best_acc,
-                                                                best_iter,
-                                                                best_epoch)
-
-    shutil.copyfile(
-        snapshot_prefix + '_iter_%d.caffemodel' % best_iter,
-        snapshot_prefix + '_best.caffemodel'
-    )
-    shutil.copyfile(
-        snapshot_prefix + '_iter_%d.solverstate' % best_iter,
-        snapshot_prefix + '_best.solverstate'
-    )
+    '''
 
     # Plot learning curve
     fig_learning_curve = plt.figure()
 
     ax1 = fig_learning_curve.add_subplot(111)
 
-    train_iter_ticks = np.arange(
-        num_train_iters, dtype=np.double) / num_train_iters_per_epoch
-    ln1 = ax1.plot(train_iter_ticks, train_loss, 'g', label='train loss')
+    ln1 = ax1.plot(history['loss'], 'g', label='train loss')
 
     ax1.plot(best_epoch, best_acc, 'k*', markersize=10)
 
@@ -422,14 +295,12 @@ def run():
 
     ax2 = ax1.twinx()
 
-    test_iter_ticks = np.arange(num_train_epochs, dtype=np.double)
-    ln2 = ax1.plot(test_iter_ticks, test_loss, 'b', label='test loss')
-    ln3 = ax2.plot(test_iter_ticks, test_acc, 'r', label='test accuracy')
+    ln2 = ax1.plot(history['val_loss'], 'b', label='test loss')
+    ln3 = ax2.plot(history['val_acc'], 'r', label='test accuracy')
 
     ax2.grid()
     ax2.set_ylabel('test accuracy')
-    ax2.set_title('Learning curve : best epoch = %d, iter = %d' %
-                  (best_epoch, best_iter))
+    ax2.set_title('Learning curve : best epoch = %d' % best_epoch)
     ax2.set_xlim([0, num_train_epochs])
     ax2.set_ylim([0.0, 1.0])
 
@@ -441,16 +312,18 @@ def run():
         train_results_dir, 'learning_curve.png'))
 
     # Show sample images from each cell of the confusion matrix
-    pred_labels = solver.test_nets[0].blobs['score'].data.argmax(1)
-    true_labels = solver.test_nets[0].blobs['label'].data
+    image_data, true_labels = queryResultToModelArguments(
+        utils.open_sqlite3_db(test_lmdb_path)
+        .execute('''select "image_data", "patch_index" from "Patches"
+                    order by random() limit ?''', (test_batch_size,))
+        .fetchall())
+    pred_labels = solver.predict(image_data, test_batch_size).argmax(1)
 
     def generate_confusion_file(true_value, pred_value):
         adj = 'true' if true_value == pred_value else 'false'
         noun = 'positive' if pred_value == 1 else 'negative'
 
-        c_data = solver.test_nets[0].blobs['data'].data[
-            (true_labels == true_value) & (pred_labels == pred_value),
-            0]
+        c_data = image_data[(true_labels == true_value) & (pred_labels == pred_value), ..., 0]
         c_count = c_data.shape[0]
         c_percent = c_count * 100. / test_batch_size
         print '%s %ss : %d / %d (%.2f%%)' % (adj, noun, c_count, test_batch_size, c_percent)

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -142,10 +142,10 @@ def run():
 
     # Create testing and training net
     train_batch_size = script_params['TRAIN_BATCH_SIZE']
-    train_lmdb_path = os.path.join(output_data_root, 'Net_TrainData')
+    train_db_path = os.path.join(output_data_root, 'Net_TrainData')
 
     test_batch_size = script_params['TEST_BATCH_SIZE']
-    test_lmdb_path = os.path.join(output_data_root, 'Net_ValData')
+    test_db_path = os.path.join(output_data_root, 'Net_ValData')
 
     net = custom_net()
     custom_solver(net)
@@ -157,8 +157,8 @@ def run():
         return retval
 
     # get number of train/test samples
-    num_train_samples = get_sample_count(train_lmdb_path)
-    num_test_samples = get_sample_count(test_lmdb_path)
+    num_train_samples = get_sample_count(train_db_path)
+    num_test_samples = get_sample_count(test_db_path)
 
     solver = net
 
@@ -211,14 +211,14 @@ def run():
     num_test_iters_per_epoch = num_test_samples / test_batch_size
     num_test_iters = num_test_epochs * num_test_iters_per_epoch
 
-    def data_generator(lmdb_path, batch_size):
+    def data_generator(db_path, batch_size):
         """Generate batches of batch_size samples from the database at
-        lmdb_path, looping through the database repeatedly, and
+        db_path, looping through the database repeatedly, and
         ignoring remaining samples when the total sample count is
         divided by batch_size.
 
         """
-        db = utils.open_sqlite3_db(lmdb_path)
+        db = utils.open_sqlite3_db(db_path)
         cursor = db.cursor()
         while True:
             cursor.execute('''select "image_data", "patch_index"
@@ -230,12 +230,12 @@ def run():
                 image_data, labels = queryResultToModelArguments(result)
                 yield image_data, U.to_categorical(labels, 2)
 
-    history = solver.fit_generator(data_generator(train_lmdb_path, train_batch_size),
+    history = solver.fit_generator(data_generator(train_db_path, train_batch_size),
                                    steps_per_epoch=num_train_iters_per_epoch,
                                    epochs=num_train_epochs,
                                    callbacks=[C.ProgbarLogger('steps'),
                                               C.ModelCheckpoint(snapshot_format)],
-                                   validation_data=data_generator(test_lmdb_path, test_batch_size),
+                                   validation_data=data_generator(test_db_path, test_batch_size),
                                    validation_steps=num_test_iters_per_epoch).history
 
     print 'Test accuracy : ', history['val_acc']
@@ -313,7 +313,7 @@ def run():
 
     # Show sample images from each cell of the confusion matrix
     image_data, true_labels = queryResultToModelArguments(
-        utils.open_sqlite3_db(test_lmdb_path)
+        utils.open_sqlite3_db(test_db_path)
         .execute('''select "image_data", "patch_index" from "Patches"
                     order by random() limit ?''', (test_batch_size,))
         .fetchall())

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -439,41 +439,24 @@ def run():
     pred_labels = solver.test_nets[0].blobs['score'].data.argmax(1)
     true_labels = solver.test_nets[0].blobs['label'].data
 
-    tp = np.where(np.logical_and(true_labels == 1, pred_labels == 1))[0]
-    tp_data = solver.test_nets[0].blobs['data'].data[tp, 0]
-    tp_percent = len(tp) * 100.0 / test_batch_size
-    print 'True Positives : %d / %d (%.2f%%)' % (len(tp), test_batch_size, tp_percent)
-    plt.figure()
-    squarePlot(tp_data)
-    plt.title('True Positive Examples - %.2f%%' % tp_percent)
-    plt.savefig(os.path.join(train_results_dir, 'sample_true_positives.png'))
+    def generate_confusion_file(true_value, pred_value):
+        adj = 'true' if true_value == pred_value else 'false'
+        noun = 'positive' if pred_value == 1 else 'negative'
 
-    tn = np.where(np.logical_and(true_labels == 0, pred_labels == 0))[0]
-    tn_data = solver.test_nets[0].blobs['data'].data[tn, 0]
-    tn_percent = len(tn) * 100.0 / test_batch_size
-    print 'True Negatives : %d / %d (%.2f%%)' % (len(tn), test_batch_size, tn_percent)
-    plt.figure()
-    squarePlot(tn_data)
-    plt.title('True Negative Examples - %.2f%%' % tn_percent)
-    plt.savefig(os.path.join(train_results_dir, 'sample_true_negatives.png'))
+        c_data = solver.test_nets[0].blobs['data'].data[
+            (true_labels == true_value) & (pred_labels == pred_value),
+            0]
+        c_count = c_data.shape[0]
+        c_percent = c_count * 100. / test_batch_size
+        print '%s %ss : %d / %d (%.2f%%)' % (adj, noun, c_count, test_batch_size, c_percent)
+        plt.figure()
+        squarePlot(c_data)
+        plt.title('%s %s examples - %.2f%%' % (adj, noun, c_percent))
+        plt.savefig(os.path.join(train_results_dir, 'sample_%s_%ss.png' % (adj, noun)))
 
-    fp = np.where(np.logical_and(true_labels == 0, pred_labels == 1))[0]
-    fp_data = solver.test_nets[0].blobs['data'].data[fp, 0]
-    fp_percent = len(fp) * 100.0 / test_batch_size
-    print 'False Positives : %d / %d (%.2f%%) ' % (len(fp), test_batch_size, fp_percent)
-    plt.figure()
-    squarePlot(fp_data)
-    plt.title('False Positive Examples - %.2f%%' % fp_percent)
-    plt.savefig(os.path.join(train_results_dir, 'sample_false_positives.png'))
-
-    fn = np.where(np.logical_and(true_labels == 1, pred_labels == 0))[0]
-    fn_data = solver.test_nets[0].blobs['data'].data[fn, 0]
-    fn_percent = len(fn) * 100.0 / test_batch_size
-    print 'False Negatives : %d / %d (%.2f%%)' % (len(fn), test_batch_size, fn_percent)
-    plt.figure()
-    squarePlot(fn_data)
-    plt.title('False Negative Examples - %.2f%%' % fn_percent)
-    plt.savefig(os.path.join(train_results_dir, 'sample_false_negatives.png'))
+    for truth in [True, False]:
+        for val in [1, 0]:
+            generate_confusion_file(true_value=(not truth) ^ val, pred_value=val)
 
 
 if __name__ == "__main__":

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -117,10 +117,12 @@ def create_uncompiled_model():
 
 # Configure and compile model
 def compile_model(model):
+    optimizer = getattr(O, script_params['SOLVER_TYPE'])
+    kwargs = {k.lower(): v for k, v in script_params['SOLVER_PARAMS'].items()}
 
-    model.compile(O.SGD(lr=script_params['BASE_LR'],
-                        momentum=script_params['MOMENTUM'],
-                        decay=script_params['GAMMA']),
+    model.compile(optimizer(lr=script_params['BASE_LR'],
+                            decay=script_params['GAMMA'],
+                            **kwargs),
                   'categorical_crossentropy',
                   metrics=['accuracy'])
 

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -146,8 +146,9 @@ def queryResultToModelArguments(result):
     of NumPy arrays to pass into various model functions.
 
     """
-    image_data = (np.array([np.frombuffer(im, dtype=np.uint8) for im, _ in result])
-                  .reshape((len(result), patch_size, patch_size, 1)) / 255.)
+    image_data = utils.scale_net_input_data(
+        np.array([np.frombuffer(im, dtype=np.uint8) for im, _ in result])
+        .reshape((len(result), patch_size, patch_size, 1)))
     labels = np.array([l for _, l in result])
     return image_data, labels
 

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -191,13 +191,9 @@ def run():
         sys.exit(0)
 
     # solve
-    # TODO figure out how to translate
-    '''
-    fig = {}
-    for layer_name in solver.net.params.keys():
-        if layer_name.startswith('conv'):
-            fig[layer_name] = plt.figure()
-    '''
+    conv_layers = [l for l in model.layers if isinstance(l, L.Conv2D)]
+    # Auto-generated names are supposed to be unique
+    fig = {l.name: plt.figure() for l in conv_layers}
 
     num_train_epochs = script_params['NUM_TRAIN_EPOCHS']
     train_batch_size = script_params['TRAIN_BATCH_SIZE']
@@ -250,33 +246,27 @@ def run():
         os.path.join(net_proto_path, 'net_best.hdf5')
     )
 
-    '''
-        # Visualize convolutional filters at each layer
-        for layer_name in solver.net.params.keys():
+    # Visualize convolutional filters at each layer
+    ep_train = num_test_epochs - 1
+    for l in conv_layers:
 
-            if layer_name.startswith('conv'):
+        plt.figure(fig[l.name].number)
 
-                plt.figure(fig[layer_name].number)
+        features = l.get_weights()[0]
 
-                features = solver.net.params[layer_name][0].data
+        h, w, n_channels, n_filters = features.shape
+        n_images = n_filters * n_channels
 
-                n_filters, n_channels, h, w = features.shape
-                n_images = n_filters * n_channels
+        squarePlot(features.transpose(2, 3, 0, 1).reshape(n_images, h, w))
 
-                squarePlot(features.reshape(n_images, h, w))
-
-                plt.title('%s - %s - Iter %s - Epoch %s' %
-                          (layer_name, str(features.shape),
-                           it_train, ep_train))
-                plt.savefig(
-                    os.path.join(
-                        train_results_dir,
-                        'filters_%s_ep_%.3d_it_%.7d.png' % (layer_name,
-                                                            ep_train,
-                                                            it_train)
-                    )
-                )
-    '''
+        plt.title('%s - %s - Epoch %s' %
+                  (l.name, str(features.shape), ep_train))
+        plt.savefig(
+            os.path.join(
+                train_results_dir,
+                'filters_%s_ep_%.3d.png' % (l.name, ep_train)
+            )
+        )
 
     # Plot learning curve
     fig_learning_curve = plt.figure()

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -101,24 +101,29 @@ def custom_net(batch_size, lmdb=None):
 
     n.conv1 = L.Convolution(n.data, kernel_size=6,
                             num_output=48, weight_filler=dict(type='xavier'))
-    n.pool1 = L.Pooling(n.conv1, kernel_size=2, stride=2, pool=P.Pooling.MAX)
+    n.relu1 = L.ReLU(n.conv1, negative_slope=0.1)
+    n.pool1 = L.Pooling(n.relu1, kernel_size=2, stride=2, pool=P.Pooling.MAX)
 
     n.conv2 = L.Convolution(n.pool1, kernel_size=5,
                             num_output=48, weight_filler=dict(type='xavier'))
-    n.pool2 = L.Pooling(n.conv2, kernel_size=2, stride=2, pool=P.Pooling.MAX)
+    n.relu2 = L.ReLU(n.conv2, negative_slope=0.1)
+    n.pool2 = L.Pooling(n.relu2, kernel_size=2, stride=2, pool=P.Pooling.MAX)
 
     n.conv3 = L.Convolution(n.pool2, kernel_size=4,
                             num_output=48, weight_filler=dict(type='xavier'))
-    n.pool3 = L.Pooling(n.conv3, kernel_size=2, stride=2, pool=P.Pooling.MAX)
+    n.relu3 = L.ReLU(n.conv3, negative_slope=0.1)
+    n.pool3 = L.Pooling(n.relu3, kernel_size=2, stride=2, pool=P.Pooling.MAX)
 
     n.conv4 = L.Convolution(n.pool3, kernel_size=2,
                             num_output=48, weight_filler=dict(type='xavier'))
-    n.pool4 = L.Pooling(n.conv4, kernel_size=2, stride=2, pool=P.Pooling.MAX)
+    n.relu4 = L.ReLU(n.conv4, negative_slope=0.1)
+    n.pool4 = L.Pooling(n.relu4, kernel_size=2, stride=2, pool=P.Pooling.MAX)
 
     n.fc1 = L.InnerProduct(n.pool4, num_output=50,
                            weight_filler=dict(type='xavier'))
+    n.relu5 = L.ReLU(n.fc1, negative_slope=0.1)
 
-    n.drop1 = L.Dropout(n.fc1, dropout_param=dict(dropout_ratio=0.5))
+    n.drop1 = L.Dropout(n.relu5, dropout_param=dict(dropout_ratio=0.5))
 
     n.score = L.InnerProduct(n.drop1, num_output=2,
                              weight_filler=dict(type='xavier'))

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -166,14 +166,24 @@ def run():
     print '\nNumber of training samples = ', num_train_samples
     print 'Number of testing samples = ', num_test_samples
 
-    print '\nNetwork structure ...'
-    for layer in model.layers:
-        print layer.name + '\t' + str(layer.output_shape)
-
-    print '\nNetwork weights ...'
-
     def with_estimated_mem(num):
         return "{} ({:.3f} MB)".format(num, num*8/1e6)
+
+    # Warning: this summation assumes the memory used by a layer for
+    # its tensors is determined only by its output.  This estimate
+    # will be an overestimate to the extent that any operation can be
+    # done "in-place", and an underestimate to the extent a layer is
+    # more complicated than a single step of input to output.
+    total_elements = 0
+    print '\nNetwork structure ...'
+    for layer in model.layers:
+        print layer.name + '\t' + str(layer.output_shape),
+        elements = train_batch_size * np.prod(layer.output_shape[1:])
+        print '\tElements:', with_estimated_mem(elements)
+        total_elements += elements
+    print 'Total elements:', with_estimated_mem(total_elements)
+
+    print '\nNetwork weights ...'
 
     total_params = 0
     for layer in model.layers:

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/TrainNet.py
@@ -164,25 +164,25 @@ def run():
     print '\nNumber of training samples = ', num_train_samples
     print 'Number of testing samples = ', num_test_samples
 
-    # TODO translate
-    '''
-    print('\nNetwork structure ...')
-    for layer_name, blob in solver.net.blobs.iteritems():
-        print(layer_name + '\t' + str(blob.data.shape))
+    print '\nNetwork structure ...'
+    for layer in model.layers:
+        print layer.name + '\t' + str(layer.output_shape)
 
-    # print parameters at each network layer
-    print('\nNetwork parameters ...')
+    print '\nNetwork weights ...'
 
-    num_params = 0
-    for layer_name, param in solver.net.params.iteritems():
-        print layer_name + '\t' + str(param[0].data.shape), str(param[1].data.shape),
+    def with_estimated_mem(num):
+        return "{} ({:.3f} MB)".format(num, num*8/1e6)
 
-        cur_num_params = np.prod(param[0].data.shape) + param[1].data.shape
-        print '\t%d parameters (%.2f MB)' % (cur_num_params, cur_num_params * 8.0 / 10.0**6)
-        num_params += cur_num_params
-
-    print 'Total number of params : %d (%.3f MB)' % (num_params, num_params * 8.0 / 10**6)
-    '''
+    total_params = 0
+    for layer in model.layers:
+        shapes = [w.shape for w in layer.get_weights()]
+        if not shapes:
+            continue
+        print layer.name + '\t' + ' '.join(map(str, shapes)),
+        num_params = sum(map(np.prod, shapes))
+        print '\tParameters:', with_estimated_mem(num_params)
+        total_params += num_params
+    print 'Total parameters:', with_estimated_mem(total_params)
 
     # ask if user wants to start training
     flag_train = raw_input('start training (y/n)?')

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/params.json
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/params.json
@@ -16,12 +16,12 @@
     "TEST_BATCH_SIZE": 1024,
     "DEPLOY_BATCH_SIZE": 4096,
     "SOLVER_TYPE": "SGD",
+    "SOLVER_PARAMS": {
+	"MOMENTUM": 0.9
+    },
     "BASE_LR": 0.01,
-    "MOMENTUM": 0.9,
     "WEIGHT_DECAY": 1e-4,
-    "LR_DECAY_POLICY": "inv",
     "GAMMA": 1e-4,
-    "POWER": 0.75,
     "VESSEL_SEED_PROBABILITY": 0.95,
     "VESSEL_SCALE": 0.1
 }

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/params.json
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/params.json
@@ -1,6 +1,5 @@
 {
     "OUTPUT_DATA_ROOT": "/media/krs0014/SegmentVesselsUsingNeuralNetworks",
-    "CAFFE_SRC_ROOT": "/home/cdeepakroy/work/Libs/caffe",
     "INPUT_DATA_ROOT": "/home/cdeepakroy/work/Libs/caffe/data/SegmentVesselsUsingNeuralNetworks",
     "PATCH_RADIUS": 32,
     "NUM_SLABS": 10,

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/utils.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/utils.py
@@ -2,6 +2,8 @@ import os
 import sys
 import shutil
 
+import sqlite3
+
 class Logger(object):
 
     def __init__(self, log_file):
@@ -36,3 +38,7 @@ def copy(inFile, outFile):
 
     # copy file
     shutil.copyfile(inFile, outFile)
+
+def open_sqlite3_db(dir):
+    """Open the sqlite3 database contained in dir.  We use "data.sqlite3"."""
+    return sqlite3.connect(os.path.join(dir, 'data.sqlite3'))

--- a/Examples/SegmentVesselsUsingNeuralNetworks/scripts/utils.py
+++ b/Examples/SegmentVesselsUsingNeuralNetworks/scripts/utils.py
@@ -42,3 +42,10 @@ def copy(inFile, outFile):
 def open_sqlite3_db(dir):
     """Open the sqlite3 database contained in dir.  We use "data.sqlite3"."""
     return sqlite3.connect(os.path.join(dir, 'data.sqlite3'))
+
+def scale_net_input_data(data):
+    """Rescale data, presumably obtained from an 8-bit grayscale image, to
+    the range [0, 1] for feeding into the network.
+
+    """
+    return data / 255.


### PR DESCRIPTION
Convert the `SegmentVesselsUsingNeuralNetworks` example to use Keras instead of Caffe, due to the former's greater flexibility and better documentation.

At the moment this removes the ability to specify different learning rate decay functions other than Keras' default, and filter visualization is only done at the end of training, not every epoch. The frequency at which training performance is recorded is also reduced to every epoch from every iteration.

On-disk, two things have been changed:
- First, extracted patches are stored in a subdirectory named after the slice image they are from instead of all in one folder. This seems to increase the speed at which the database is built when a large number of patches are extracted.
- The database used is now SQLite instead of LMDB