### PR TITLE
WIP: ConvertTubesToImage issue

### DIFF
--- a/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
+++ b/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
@@ -194,6 +194,8 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
     {
     TubeType * tube = ( TubeType * )TubeIterator->GetPointer();
 
+    tube->ComputeObjectToWorldTransform();
+
     typename TubeType::TransformType * tubeIndexPhysTransform =
       tube->GetIndexToWorldTransform();
 

--- a/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
+++ b/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
@@ -146,6 +146,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
   OutputImage->SetRegions( region );
   OutputImage->SetSpacing( this->m_Spacing );
   OutputImage->SetOrigin( this->m_Origin );
+  OutputImage->SetDirection( this->m_Direction );
   OutputImage->Allocate();
   OutputImage->FillBuffer( 0 );
 
@@ -158,6 +159,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
     m_RadiusImage->SetRegions( region );
     m_RadiusImage->SetSpacing( this->m_Spacing );
     m_RadiusImage->SetOrigin( this->m_Origin );
+    m_RadiusImage->SetDirection( this->m_Direction );
     m_RadiusImage->Allocate();
     m_RadiusImage->FillBuffer( 0 );
     }
@@ -169,6 +171,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
     m_TangentImage->SetRegions( region );
     m_TangentImage->SetSpacing( this->m_Spacing );
     m_TangentImage->SetOrigin( this->m_Origin );
+    m_TangentImage->SetDirection( this->m_Direction );
     m_TangentImage->Allocate();
     TangentPixelType v;
     v.Fill( 0 );

--- a/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
+++ b/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
@@ -243,6 +243,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
         // Radius Image and Density image with radius
         if( m_UseRadius )
           {
+	  // TODO it looks like we're assuming isometry here
           double phys_pt_radius = tubePoint->GetRadius() *
                                       tube
                                       ->GetIndexToObjectTransform()

--- a/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
+++ b/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
@@ -198,27 +198,25 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
 
   while( TubeIterator != tubeList->end() )
     {
+    TubeType * tube = ( TubeType * )TubeIterator->GetPointer();
+
     // Force the computation of the tangents
     if( m_BuildTangentImage )
       {
-      ( ( TubeType * )( ( *TubeIterator ).GetPointer() ) )->
-        RemoveDuplicatePoints();
-      ( ( TubeType * )( ( *TubeIterator ).GetPointer() ) )->
-        ComputeTangentAndNormals();
+      tube->RemoveDuplicatePoints();
+      tube->ComputeTangentAndNormals();
       }
 
-    for( unsigned int k=0; k <
-      ( ( TubeType * )( TubeIterator->GetPointer() ) )->GetNumberOfPoints();
-      k++ )
+    for( unsigned int k=0; k < tube->GetNumberOfPoints(); k++ )
       {
       bool IsInside = true;
       typedef typename TubeType::TubePointType TubePointType;
       const TubePointType* tubePoint = static_cast<const TubePointType*>(
-        ( ( TubeType * ) ( TubeIterator->GetPointer() ) )->GetPoint( k ) );
+        tube->GetPoint( k ) );
       for( unsigned int i=0; i<ObjectDimension; i++ )
         {
         point[i] = ( ( tubePoint->GetPosition()[i] *
-          ( ( TubeType * )( TubeIterator->GetPointer() ) )->
+          tube->
             GetIndexToObjectTransform()->GetScaleComponent()[i] )
             - this->m_Origin[i] ) / this->m_Spacing[i];
 
@@ -260,8 +258,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
         if( m_UseRadius )
           {
           double phys_pt_radius = tubePoint->GetRadius() *
-                                      ( ( TubeType * )( ( TubeIterator )
-                                                    ->GetPointer() ) )
+                                      tube
                                       ->GetIndexToObjectTransform()
                                       ->GetScaleComponent()[0];
           if( m_BuildRadiusImage )

--- a/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
+++ b/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
@@ -291,10 +291,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
                   {
                   index2[0]=( long )( point[0]+x+0.5 );
                   index2[1]=( long )( point[1]+y+0.5 );
-                  if( ( unsigned long )index2[0] <
-                    OutputImage->GetLargestPossibleRegion().GetSize()[0]
-                    && ( unsigned long )index2[1] <
-                    OutputImage->GetLargestPossibleRegion().GetSize()[1] )
+                  if( OutputImage->GetLargestPossibleRegion().IsInside( index2 ) )
                     {
                     typedef typename OutputImageType::PixelType PixelType;
                     if( m_Cumulative )
@@ -333,18 +330,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
                     index2[2]=( long )( point[2]+z+0.5 );
 
                     // Test that point is within the output image boundries
-                    if( index2[0] >= 0
-                         && index2[1] >= 0
-                         && index2[2] >= 0
-                         && ( unsigned long )index2[0] <
-                             OutputImage->GetLargestPossibleRegion()
-                                          .GetSize()[0]
-                         && ( unsigned long )index2[1] <
-                             OutputImage->GetLargestPossibleRegion()
-                                          .GetSize()[1]
-                         && ( unsigned long )index2[2] <
-                             OutputImage->GetLargestPossibleRegion()
-                                          .GetSize()[2] )
+                    if( OutputImage->GetLargestPossibleRegion().IsInside( index2 ) )
                       {
                       OutputImage->SetPixel( index2, 1 );
                       if( m_BuildRadiusImage )

--- a/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
+++ b/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
@@ -42,13 +42,6 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
   m_BuildRadiusImage = false;
   m_BuildTangentImage = false;
   m_FallOff = 0.0;
-  this->m_Size.Fill( 0 );
-  unsigned int i;
-  for( i=0; i<ObjectDimension; i++ )
-    {
-    this->m_Spacing[i] = 1;
-    this->m_Origin[i] = 0;
-    }
 
   // This is a little bit tricky since the 2nd an 3rd outputs are
   //   not always computed

--- a/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
+++ b/Base/Filtering/itktubeTubeSpatialObjectToImageFilter.hxx
@@ -143,9 +143,7 @@ TubeSpatialObjectToImageFilter< ObjectDimension, TOutputImage, TRadiusImage,
   index.Fill( 0 );
   region.SetIndex( index );
 
-  OutputImage->SetLargestPossibleRegion( region );  //
-  OutputImage->SetBufferedRegion( region );         // set the region
-  OutputImage->SetRequestedRegion( region );        //
+  OutputImage->SetRegions( region );
   OutputImage->SetSpacing( this->m_Spacing );
   OutputImage->SetOrigin( this->m_Origin );
   OutputImage->Allocate();

--- a/ITKModules/TubeTKITK/include/tubeConvertTubesToImage.hxx
+++ b/ITKModules/TubeTKITK/include/tubeConvertTubesToImage.hxx
@@ -51,6 +51,8 @@ ConvertTubesToImage< Dimension, TOutputPixel >
 
     m_Filter->SetSize( pTemplateImage->GetLargestPossibleRegion().GetSize() );
     m_Filter->SetSpacing( pTemplateImage->GetSpacing() );
+    m_Filter->SetDirection( pTemplateImage->GetDirection() );
+    m_Filter->SetOrigin( pTemplateImage->GetOrigin() );
 
     this->Modified();
     }


### PR DESCRIPTION
The `ConvertTubesToImage` program seems to fail to properly handle template images with non-zero offset, nor is there any mention made of the direction information in the code. While the pixel data in the output image appears correct, its origin and direction are fixed at zero and identity, respectively.

I'm running into problems trying to fix this The Right Way™️, however. Simply passing the origin and direction through breaks things.  Instead chaining `TubeSpatialObject::GetIndexToWorldTransform().TransformPoint` and `Image::TransformPhysicalPointToContinuousIndex` for the coordinate transformation doesn't help. Interestingly, stopping with passing the origin and direction through restores functionality with the changed coordinate transformation in place.

The TRE files are probably fine, since VesselView renders them aligned with the input / template images.

@aylward The context here is the stroke data.