### PR TITLE
Add an option to SegmentTubes to take a seed point file with points in physical coordinates

### DIFF
--- a/Applications/SegmentTubes/SegmentTubes.cxx
+++ b/Applications/SegmentTubes/SegmentTubes.cxx
@@ -186,6 +186,25 @@ int DoIt( int argc, char * argv[] )
     segmentTubesFilter->SetSeedIndexFromFileList( seedIndexList, scaleList );
     }
 
+  if( !seedListFilePhysicalNoScale.empty() )
+    {
+    pointList.clear();
+    std::ifstream readStream;
+    readStream.open( seedListFilePhysicalNoScale.c_str(), std::ios::binary |
+      std::ios::in );
+    std::string line;
+    while( std::getline( readStream, line ) )
+      {
+      std::istringstream iss( line );
+      for( unsigned int i = 0; i < VDimension; ++i )
+        {
+        iss >> point[i];
+        }
+      pointList.push_back( point );
+      }
+    segmentTubesFilter->SetSeedPhysicalCoordinatesList( pointList );
+    }
+
   if( !seedMask.empty() )
     {
     typename MaskReaderType::Pointer maskReader = MaskReaderType::New();

--- a/Applications/SegmentTubes/SegmentTubes.xml
+++ b/Applications/SegmentTubes/SegmentTubes.xml
@@ -40,6 +40,14 @@
       <description>List seed points stored in a file.  The format is lines of the form I1 ... ID S, where Ij is the jth component of the seed point, as an index, and S the seed point's scale.</description>
       <default></default>
     </file>
+    <file>
+      <name>seedListFilePhysicalNoScale</name>
+      <label>Physical Point Seed List, No Scale</label>
+      <longflag>seedListPhysicalNoScale</longflag>
+      <description>List seed points stored in a file.  The format is lines of the form I1 ... ID, where Ij is the jth component of the seed point, as a physical point.</description>
+      <channel>input</channel>
+      <default></default>
+    </file>
     <double>
       <name>scale</name>
       <label>Scale of Ridge</label>

--- a/Applications/SegmentTubes/SegmentTubes.xml
+++ b/Applications/SegmentTubes/SegmentTubes.xml
@@ -61,7 +61,7 @@
       <label>Seed physical coordinate</label>
       <longflag>seedP</longflag>
       <flag>p</flag>
-      <description>Phisycal coordinate seed for ridge extraction</description>
+      <description>Physical coordinate seed for ridge extraction</description>
       <default></default>
     </point>
     <image>

--- a/Applications/SegmentTubes/SegmentTubes.xml
+++ b/Applications/SegmentTubes/SegmentTubes.xml
@@ -37,7 +37,7 @@
       <channel>input</channel>
       <flag>f</flag>
       <longflag>seedList</longflag>
-      <description>List seed points stored in a file</description>
+      <description>List seed points stored in a file.  The format is lines of the form I1 ... ID S, where Ij is the jth component of the seed point, as an index, and S the seed point's scale.</description>
       <default></default>
     </file>
     <double>


### PR DESCRIPTION
This PR teaches `SegmentTubes` the option `--seedListPhysicalNoScale`, which accepts a file whose lines are the physical coordinates of seed points, using a separately set scale.

It also documents the format expected by the existing `--seedList` option, and fixes a small typo in the description of the `--seedP` option.