### PR TITLE
ENH: Remove reference to Qt.  Support env vars for externaldata.

### DIFF
--- a/CMake/KWStyle/Headers/BatHeader.txt
+++ b/CMake/KWStyle/Headers/BatHeader.txt
@@ -1,0 +1,21 @@
+REM
+REM
+REM Library:   TubeTK
+REM
+REM Copyright 2010 Kitware Inc. 28 Corporate Drive,
+REM Clifton Park, NY, 12065, USA.
+REM
+REM All rights reserved.
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM       http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM

--- a/CMake/Superbuild/ExternalProjectsConfig.cmake
+++ b/CMake/Superbuild/ExternalProjectsConfig.cmake
@@ -58,6 +58,21 @@ set( LIBSVM_HASH_OR_TAG 9bc3630f0f15fed7a5119c228c4d260574b4b6b2 )
 # Kitware Modules
 ###########################################################
 
+# Insight Segmentation and Registration Toolkit
+set( ITK_URL
+  ${github_protocol}://github.com/InsightSoftwareConsortium/ITK.git )
+set( ITK_HASH_OR_TAG v4.12.1 )
+
+# Slicer Execution Model
+set( SlicerExecutionModel_URL
+  ${github_protocol}://github.com/Slicer/SlicerExecutionModel.git )
+set( SlicerExecutionModel_HASH_OR_TAG
+  fa5f22e6346f8115381c1a242c4c50afe0ee8a50 )
+
+# Visualization Toolkit 
+set( VTK_URL ${github_protocol}://github.com/Kitware/VTK.git )
+set( VTK_HASH_OR_TAG v8.0.1 )
+
 # KWStyle
 set( KWStyle_URL ${git_protocol}://github.com/Kitware/KWStyle.git )
 set( KWStyle_HASH_OR_TAG e03980ff514d5248a9f95ea355dcd9eff78c62d3 )
@@ -74,22 +89,10 @@ set( TubeTKITK_HASH_OR_TAG "")
 # MinimalPathExtraction
 set( MinimalPathExtraction_URL
   ${git_protocol}://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git )
-set( MinimalPathExtraction_HASH_OR_TAG 21b01c83ffe9717e280020edb7f73996341945e9 )
+set( MinimalPathExtraction_HASH_OR_TAG
+  21b01c83ffe9717e280020edb7f73996341945e9 )
 
 set( TubeTK_ITK_MODULES
   TubeTKITK
   MinimalPathExtraction
   )
-
-# Insight Segmentation and Registration Toolkit
-set( ITK_URL ${github_protocol}://github.com/InsightSoftwareConsortium/ITK.git )
-set( ITK_HASH_OR_TAG v4.12.1 )
-
-# Slicer Execution Model
-set( SlicerExecutionModel_URL
-  ${github_protocol}://github.com/Slicer/SlicerExecutionModel.git )
-set( SlicerExecutionModel_HASH_OR_TAG 61bb14d57ff45c8de0f506e23b6ec982fcdf0da2 )
-
-# Visualization Toolkit 
-set( VTK_URL ${github_protocol}://github.com/Kitware/VTK.git )
-set( VTK_HASH_OR_TAG v8.0.1 )

--- a/CMake/TubeTKBlockSetCMakeOSXVariables.cmake
+++ b/CMake/TubeTKBlockSetCMakeOSXVariables.cmake
@@ -103,18 +103,8 @@ if( APPLE )
     string( REGEX MATCH "MacOSX([0-9]+\\.[0-9]+)\\.sdk" _match
       "${CMAKE_OSX_SYSROOT}" )
     set( SDK_VERSION "${CMAKE_MATCH_1}" )
-    if( "${SDK_VERSION}" VERSION_GREATER "10.8" )
-      execute_process( COMMAND "otool -L $QT_QMAKE_COMMAND | grep stdc"
-        OUTPUT_VARIABLE QMAKE_USE_STDC
-        OUTPUT_STRIP_TRAILING_WHITESPACE )
-      if( "x${QMAKE_USE_STDC}x" STREQUAL "xx" )
-        set( CMAKE_OSX_DEPLOYMENT_TARGET "${SDK_VERSION}" CACHE PATH
-          "Deployment target needs to be explicitly set." FORCE )
-      else()
-        set( CMAKE_OSX_DEPLOYMENT_TARGET "10.8" CACHE PATH
-          "Deployment target needs to be explicitly set." FORCE )
-      endif()
-    endif()
+    set( CMAKE_OSX_DEPLOYMENT_TARGET "${SDK_VERSION}" CACHE PATH
+      "Deployment target needs to be explicitly set." FORCE )
   endif()
 
   if( NOT "${CMAKE_OSX_SYSROOT}" STREQUAL "" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,10 @@ configure_file( ${TubeTK_SOURCE_DIR}/CMake/CTestCustom.cmake.in
 
 set( TubeTK_BUILD_TESTING ${BUILD_TESTING} )
 
+if( DEFINED "ENV{ExternalData_OBJECT_STORES}" )
+  set( ExternalData_OBJECT_STORES $ENV{ExternalData_OBJECT_STORES} )
+endif()
+
 #
 # Doxygen documentation setup.
 #


### PR DESCRIPTION
No longer test for using Qt on MacOS compiled prior to 10.8.

Use an externaldata directory for downloaded data, if an environment
var specifies one.