### PR TITLE
BUG: Python wrapping of SegmentTubes accessing Index as object

### DIFF
--- a/Base/Segmentation/itktubeRidgeExtractor.hxx
+++ b/Base/Segmentation/itktubeRidgeExtractor.hxx
@@ -124,8 +124,8 @@ RidgeExtractor<TInputImage>
   m_MaxXChange = 3.0;
   m_MinRidgeness = 0.70;    // near 1 = harder
   m_MinRidgenessStart = 0.69;
-  m_MinRoundness = 0.25;    // near 1 = harder
-  m_MinRoundnessStart = 0.2;
+  m_MinRoundness = 0.15;    // near 1 = harder
+  m_MinRoundnessStart = 0.1;
   m_MinCurvature = 0.1;
   m_MinCurvatureStart = 0.05;
   m_MinLevelness = 0.5;

--- a/Base/Segmentation/itktubeTubeExtractor.hxx
+++ b/Base/Segmentation/itktubeTubeExtractor.hxx
@@ -390,7 +390,7 @@ TubeExtractor<TInputImage>
   if( this->m_StatusCallBack )
     {
     char s[80];
-    std::sprintf( s, "%ld points", tube->GetPoints().size() );
+    std::sprintf( s, "%zd points", tube->GetPoints().size() );
     this->m_StatusCallBack( "Extract: Ridge", s, 0 );
     }
 

--- a/ITKModules/TubeTKITK/include/tubeSegmentTubes.h
+++ b/ITKModules/TubeTKITK/include/tubeSegmentTubes.h
@@ -91,12 +91,12 @@ public:
   tubeWrapGetMacro( Debug, bool, Filter );
 
   /** Set ExtractBound Minimum */
-  tubeWrapSetConstReferenceMacro( ExtractBoundMin, IndexType, Filter );
-  tubeWrapGetConstReferenceMacro( ExtractBoundMin, IndexType, Filter );
+  tubeWrapSetMacro( ExtractBoundMin, IndexType, Filter );
+  tubeWrapGetMacro( ExtractBoundMin, IndexType, Filter );
 
   /** Set ExtractBound Maximum */
-  tubeWrapSetConstReferenceMacro( ExtractBoundMax, IndexType, Filter );
-  tubeWrapGetConstReferenceMacro( ExtractBoundMax, IndexType, Filter );
+  tubeWrapSetMacro( ExtractBoundMax, IndexType, Filter );
+  tubeWrapGetMacro( ExtractBoundMax, IndexType, Filter );
 
   /*** Extract the ND tube given the position of the first point
    * and the tube ID */


### PR DESCRIPTION
ExtractBounds is an index, so should be directly addressed in
Get/Set macros.

Also, reduced threshold on Roundness - making it less sensitive.