### PR TITLE
ENH: Support setting parameter files in Python-wrapped SegmentTubes

### DIFF
--- a/ITKModules/TubeTKITK/include/tubeSegmentTubes.h
+++ b/ITKModules/TubeTKITK/include/tubeSegmentTubes.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "tubeWrappingMacros.h"
 
 #include "itktubeTubeExtractor.h"
+#include "itktubeTubeExtractorIO.h"
 
 namespace tube
 {
@@ -59,6 +60,8 @@ public:
   typedef typename FilterType::TubeGroupType           TubeGroupType;
 
   typedef typename FilterType::ContinuousIndexType     ContinuousIndexType;
+
+  typedef itk::tube::TubeExtractorIO< ImageType >      TubeExtractorIOType;
 
   /** Method for creation through the object factory. */
   itkNewMacro( Self );
@@ -97,6 +100,8 @@ public:
   /** Set ExtractBound Maximum */
   tubeWrapSetMacro( ExtractBoundMax, IndexType, Filter );
   tubeWrapGetMacro( ExtractBoundMax, IndexType, Filter );
+
+  void SetParameterFile( const char *filename );
 
   /*** Extract the ND tube given the position of the first point
    * and the tube ID */

--- a/ITKModules/TubeTKITK/include/tubeSegmentTubes.hxx
+++ b/ITKModules/TubeTKITK/include/tubeSegmentTubes.hxx
@@ -59,6 +59,16 @@ SegmentTubes< TInputImage >
 template< class TInputImage >
 void
 SegmentTubes< TInputImage >
+::SetParameterFile( const char *filename )
+{
+  TubeExtractorIOType teReader;
+  teReader.SetTubeExtractor( this->m_Filter );
+  teReader.Read( filename );
+}
+
+template< class TInputImage >
+void
+SegmentTubes< TInputImage >
 ::PrintSelf( std::ostream & os, itk::Indent indent ) const
 {
   Superclass::PrintSelf( os, indent );

--- a/ITKModules/TubeTKITK/tubetk-depends.cmake
+++ b/ITKModules/TubeTKITK/tubetk-depends.cmake
@@ -36,6 +36,7 @@
 #
 
 set( TubeTKITK_DEPENDS
+  IO
   Common
   Numerics
   Filtering


### PR DESCRIPTION
Adds method `SetParameterFile` to `itk.SegmentTubes`