### PR TITLE
ENH: Add option to CLI Helper Function to only compile app for 3D

### DIFF
--- a/apps/CLI/tubeCLIHelperFunctions.h
+++ b/apps/CLI/tubeCLIHelperFunctions.h
@@ -73,7 +73,7 @@ int ParseArgsAndCallDoIt( const std::string & inputImage, int argc,
 
 #ifndef PARSE_ARGS_FLOAT_ONLY
 
-#ifdef SUPPORT_2D_IMAGES
+#ifndef PARSE_ARGS_3D_ONLY
     if( dimension == 2 )
       {
       switch( componentType )
@@ -134,7 +134,7 @@ int ParseArgsAndCallDoIt( const std::string & inputImage, int argc,
       }
 
 #else
-#ifdef SUPPORT_2D_IMAGES
+#ifndef PARSE_ARGS_3D_ONLY
     if( dimension == 2 )
       {
       return DoIt< float, 2 >( argc, argv );

--- a/apps/SegmentBinaryImageSkeleton3D/SegmentBinaryImageSkeleton3D.cxx
+++ b/apps/SegmentBinaryImageSkeleton3D/SegmentBinaryImageSkeleton3D.cxx
@@ -34,6 +34,8 @@ limitations under the License.
 
 #include "SegmentBinaryImageSkeleton3DCLP.h"
 
+#define PARSE_ARGS_3D_ONLY true
+
 template< class TPixel, unsigned int VDimension >
 int DoIt( int argc, char * argv[] );
 


### PR DESCRIPTION
Select apps only work with 3D images.   The CLI helper function (Do_It) is typically templated by image dimension and supports 2D and 3D images.   The commit allows an app to #define a variation to enable only having a 3D template argument for image dimension during compilation.