### PR TITLE
ENH: Apps are build as part of the main project

### DIFF
--- a/apps/AtlasBuilderUsingIntensity/CMakeLists.txt
+++ b/apps/AtlasBuilderUsingIntensity/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME AtlasBuilderUsingIntensity )
 
-project( ${MODULE_NAME} )
-
 set( AtlasBuilderUsingIntensity_H_Files
   itktubeCompleteImageResampleFilter.h
   itktubeMeanAndSigmaImageBuilder.h

--- a/apps/ComputeBinaryImageSimilarityMetrics/CMakeLists.txt
+++ b/apps/ComputeBinaryImageSimilarityMetrics/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeBinaryImageSimilarityMetrics )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeImageSimilarityMetrics/CMakeLists.txt
+++ b/apps/ComputeImageSimilarityMetrics/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeImageSimilarityMetrics )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeImageStatistics/CMakeLists.txt
+++ b/apps/ComputeImageStatistics/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeImageStatistics )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeImageToTubeRigidMetricImage/CMakeLists.txt
+++ b/apps/ComputeImageToTubeRigidMetricImage/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeImageToTubeRigidMetricImage )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeRegionSignatures/CMakeLists.txt
+++ b/apps/ComputeRegionSignatures/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeRegionSignatures )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeSegmentTubesParameters/CMakeLists.txt
+++ b/apps/ComputeSegmentTubesParameters/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeSegmentTubesParameters )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeTrainingMask/CMakeLists.txt
+++ b/apps/ComputeTrainingMask/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeTrainingMask )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeTubeFlyThroughImage/CMakeLists.txt
+++ b/apps/ComputeTubeFlyThroughImage/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeTubeFlyThroughImage )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeTubeGraphProbability/CMakeLists.txt
+++ b/apps/ComputeTubeGraphProbability/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeTubeGraphProbability )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeTubeGraphSimilarityKernelMatrix/CMakeLists.txt
+++ b/apps/ComputeTubeGraphSimilarityKernelMatrix/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeTubeGraphSimilarityKernelMatrix )
 
-project( ${MODULE_NAME} )
-
 set( TubeGraphKernel_H_Files
   GraphKernel.h
   tubeShortestPathKernel.h

--- a/apps/ComputeTubeMeasures/CMakeLists.txt
+++ b/apps/ComputeTubeMeasures/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeTubeMeasures )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeTubeProbability/CMakeLists.txt
+++ b/apps/ComputeTubeProbability/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeTubeProbability )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ComputeTubeTortuosityMeasures/CMakeLists.txt
+++ b/apps/ComputeTubeTortuosityMeasures/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ComputeTubeTortuosityMeasures )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/Convert4DImageTo3DImages/CMakeLists.txt
+++ b/apps/Convert4DImageTo3DImages/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME Convert4DImageTo3DImages )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ConvertCSVToImages/CMakeLists.txt
+++ b/apps/ConvertCSVToImages/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertCSVToImages )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ConvertImagesToCSV/CMakeLists.txt
+++ b/apps/ConvertImagesToCSV/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertImagesToCSV )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ConvertShrunkenSeedImageToList/CMakeLists.txt
+++ b/apps/ConvertShrunkenSeedImageToList/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertShrunkenSeedImageToList )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ConvertSpatialGraphToImage/CMakeLists.txt
+++ b/apps/ConvertSpatialGraphToImage/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertSpatialGraphToImage )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ConvertTRE/CMakeLists.txt
+++ b/apps/ConvertTRE/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertTRE )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ConvertTubesToDensityImage/CMakeLists.txt
+++ b/apps/ConvertTubesToDensityImage/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertTubesToDensityImage )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ConvertTubesToImage/CMakeLists.txt
+++ b/apps/ConvertTubesToImage/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertTubesToImage )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ConvertTubesToSurface/CMakeLists.txt
+++ b/apps/ConvertTubesToSurface/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertTubesToSurface )
 
-project( ${MODULE_NAME} )
-
 set( ConvertTubesToSurface_H_Files
   )
 

--- a/apps/ConvertTubesToTubeGraph/CMakeLists.txt
+++ b/apps/ConvertTubesToTubeGraph/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertTubesToTubeGraph )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/ConvertTubesToTubeTree/CMakeLists.txt
+++ b/apps/ConvertTubesToTubeTree/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ConvertTubesToTubeTree )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME
     ${MODULE_NAME}

--- a/apps/CropImage/CMakeLists.txt
+++ b/apps/CropImage/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME CropImage )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/CropTubes/CMakeLists.txt
+++ b/apps/CropTubes/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME CropTubes )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/DeblendTomosynthesisSlicesUsingPrior/CMakeLists.txt
+++ b/apps/DeblendTomosynthesisSlicesUsingPrior/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME DeblendTomosynthesisSlicesUsingPrior )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/EnhanceCoherenceAndEdgesUsingDiffusion/CMakeLists.txt
+++ b/apps/EnhanceCoherenceAndEdgesUsingDiffusion/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME EnhanceCoherenceAndEdgesUsingDiffusion )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/EnhanceCoherenceUsingDiffusion/CMakeLists.txt
+++ b/apps/EnhanceCoherenceUsingDiffusion/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME EnhanceCoherenceUsingDiffusion )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/EnhanceContrastUsingAHE/CMakeLists.txt
+++ b/apps/EnhanceContrastUsingAHE/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME EnhanceContrastUsingAHE )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/EnhanceContrastUsingPrior/CMakeLists.txt
+++ b/apps/EnhanceContrastUsingPrior/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME EnhanceContrastUsingPrior )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/EnhanceEdgesUsingDiffusion/CMakeLists.txt
+++ b/apps/EnhanceEdgesUsingDiffusion/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME EnhanceEdgesUsingDiffusion )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/EnhanceTubesUsingDiffusion/CMakeLists.txt
+++ b/apps/EnhanceTubesUsingDiffusion/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME EnhanceTubesUsingDiffusion )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/EnhanceTubesUsingDiscriminantAnalysis/CMakeLists.txt
+++ b/apps/EnhanceTubesUsingDiscriminantAnalysis/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME EnhanceTubesUsingDiscriminantAnalysis )
 
-project( ${MODULE_NAME} )
-
 set( ${MODULE_NAME}_EXTERNAL_LIBS )
 if( TubeTK_USE_LIBSVM )
   find_package( LIBSVM REQUIRED )

--- a/apps/EnhanceUsingDiscriminantAnalysis/CMakeLists.txt
+++ b/apps/EnhanceUsingDiscriminantAnalysis/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME EnhanceUsingDiscriminantAnalysis )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/EnhanceUsingNJetDiscriminantAnalysis/CMakeLists.txt
+++ b/apps/EnhanceUsingNJetDiscriminantAnalysis/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME EnhanceUsingNJetDiscriminantAnalysis )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/ExtractMetricImageSlice/CMakeLists.txt
+++ b/apps/ExtractMetricImageSlice/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ExtractMetricImageSlice )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/ImageMath/CMakeLists.txt
+++ b/apps/ImageMath/CMakeLists.txt
@@ -20,10 +20,10 @@
 #
 ##############################################################################
 
-project( ImageMath )
+set( MODULE_NAME ImageMath )
 
 SEMMacroBuildCLI(
-  NAME ${PROJECT_NAME}
+  NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}

--- a/apps/ImageMath/Testing/CMakeLists.txt
+++ b/apps/ImageMath/Testing/CMakeLists.txt
@@ -26,529 +26,529 @@ include_regular_expression( "^.*$" )
 set( TEMP ${TubeTK_BINARY_DIR}/Temporary )
 
 set( PROJ_EXE
-  ${TubeTK_LAUNCHER} $<TARGET_FILE:${PROJECT_NAME}> )
+  ${TubeTK_LAUNCHER} $<TARGET_FILE:${MODULE_NAME}> )
 
 # Test1
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test1
+            NAME ${MODULE_NAME}-Test1
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -i -1 1 -100 100
-               -w ${TEMP}/${PROJECT_NAME}Test1.mha )
+               -w ${TEMP}/${MODULE_NAME}Test1.mha )
 
 # Test1-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test1-Compare
+            NAME ${MODULE_NAME}-Test1-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test1.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test1.mha}
+               -t ${TEMP}/${MODULE_NAME}Test1.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test1.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test1-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test1 )
+set_tests_properties( ${MODULE_NAME}-Test1-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test1 )
 
 # Test2
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test2
+            NAME ${MODULE_NAME}-Test2
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -b 5
-               -w ${TEMP}/${PROJECT_NAME}Test2_meanfield.mha
+               -w ${TEMP}/${MODULE_NAME}Test2_meanfield.mha
                -a 0 1 DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
-               -I ${TEMP}/${PROJECT_NAME}Test2_meanfield.mha
-               -w ${TEMP}/${PROJECT_NAME}Test2.mha )
+               -I ${TEMP}/${MODULE_NAME}Test2_meanfield.mha
+               -w ${TEMP}/${MODULE_NAME}Test2.mha )
 
 # Test2-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test2-Compare
+            NAME ${MODULE_NAME}-Test2-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test2.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test2.mha}
+               -t ${TEMP}/${MODULE_NAME}Test2.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test2.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test2-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test2 )
+set_tests_properties( ${MODULE_NAME}-Test2-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test2 )
 
 # Test3
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test3
+            NAME ${MODULE_NAME}-Test3
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -S 1234
                -n -1 1 10 0.2
-               -w ${TEMP}/${PROJECT_NAME}Test3.mha )
+               -w ${TEMP}/${MODULE_NAME}Test3.mha )
 
 # Test3-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test3-Compare
+            NAME ${MODULE_NAME}-Test3-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test3.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test3.mha}
+               -t ${TEMP}/${MODULE_NAME}Test3.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test3.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test3-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test3 )
+set_tests_properties( ${MODULE_NAME}-Test3-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test3 )
 
 # Test4
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test4
+            NAME ${MODULE_NAME}-Test4
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -S 1234
                -N -1 1 10 0.2
-               -w ${TEMP}/${PROJECT_NAME}Test4.mha )
+               -w ${TEMP}/${MODULE_NAME}Test4.mha )
 
 # Test4-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test4-Compare
+            NAME ${MODULE_NAME}-Test4-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test4.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test4.mha}
+               -t ${TEMP}/${MODULE_NAME}Test4.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test4.mha}
                -i 0.01 )
-set_tests_properties( ${PROJECT_NAME}-Test4-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test4 )
+set_tests_properties( ${MODULE_NAME}-Test4-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test4 )
 
 # Test5
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test5
+            NAME ${MODULE_NAME}-Test5
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -f 10
-                 DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test2.mha}
-               -w ${TEMP}/${PROJECT_NAME}Test5.mha )
+                 DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test2.mha}
+               -w ${TEMP}/${MODULE_NAME}Test5.mha )
 
 # Test5-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test5-Compare
+            NAME ${MODULE_NAME}-Test5-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test5.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test5.mha}
+               -t ${TEMP}/${MODULE_NAME}Test5.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test5.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test5-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test5 )
+set_tests_properties( ${MODULE_NAME}-Test5-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test5 )
 
 # Test6
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test6
+            NAME ${MODULE_NAME}-Test6
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
-               -a 0.95 0.05 DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test5.mha}
-               -w ${TEMP}/${PROJECT_NAME}Test6.mha )
+               -a 0.95 0.05 DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test5.mha}
+               -w ${TEMP}/${MODULE_NAME}Test6.mha )
 
 # Test6-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test6-Compare
+            NAME ${MODULE_NAME}-Test6-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test6.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test6.mha}
+               -t ${TEMP}/${MODULE_NAME}Test6.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test6.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test6-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test6 )
+set_tests_properties( ${MODULE_NAME}-Test6-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test6 )
 
 # Test7
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test7
+            NAME ${MODULE_NAME}-Test7
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -t -1 -0.33 -1 1
-               -w ${TEMP}/${PROJECT_NAME}Test7.mha )
+               -w ${TEMP}/${MODULE_NAME}Test7.mha )
 
 # Test7-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test7-Compare
+            NAME ${MODULE_NAME}-Test7-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test7.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test7.mha}
+               -t ${TEMP}/${MODULE_NAME}Test7.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test7.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test7-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test7 )
+set_tests_properties( ${MODULE_NAME}-Test7-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test7 )
 
 # Test8
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test8
+            NAME ${MODULE_NAME}-Test8
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -m -1 -0.33 DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha} 0
-               -w ${TEMP}/${PROJECT_NAME}Test8.mha )
+               -w ${TEMP}/${MODULE_NAME}Test8.mha )
 
 # Test8-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test8-Compare
+            NAME ${MODULE_NAME}-Test8-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test8.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test8.mha}
+               -t ${TEMP}/${MODULE_NAME}Test8.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test8.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test8-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test8 )
+set_tests_properties( ${MODULE_NAME}-Test8-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test8 )
 
 # Test9
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test9
+            NAME ${MODULE_NAME}-Test9
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/GDS0015_1.mha}
                -M 0 10 255 0
-               -W 2 ${TEMP}/${PROJECT_NAME}Test9.mha )
+               -W 2 ${TEMP}/${MODULE_NAME}Test9.mha )
 
 # Test9-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test9-Compare
+            NAME ${MODULE_NAME}-Test9-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test9.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test9.mha}
+               -t ${TEMP}/${MODULE_NAME}Test9.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test9.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test9-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test9 )
+set_tests_properties( ${MODULE_NAME}-Test9-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test9 )
 
 # Test10
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test10
+            NAME ${MODULE_NAME}-Test10
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/GDS0015_1.mha}
                -M 1 5 255 0
-               -W 2 ${TEMP}/${PROJECT_NAME}Test10.mha )
+               -W 2 ${TEMP}/${MODULE_NAME}Test10.mha )
 
 # Test10-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test10-Compare
+            NAME ${MODULE_NAME}-Test10-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test10.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test10.mha}
+               -t ${TEMP}/${MODULE_NAME}Test10.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test10.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test10-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test10 )
+set_tests_properties( ${MODULE_NAME}-Test10-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test10 )
 
 # Test11
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test11
+            NAME ${MODULE_NAME}-Test11
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -b 10
-               -w ${TEMP}/${PROJECT_NAME}Test11.mha )
+               -w ${TEMP}/${MODULE_NAME}Test11.mha )
 
 # Test11-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test11-Compare
+            NAME ${MODULE_NAME}-Test11-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test11.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test11.mha}
+               -t ${TEMP}/${MODULE_NAME}Test11.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test11.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test11-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test11 )
+set_tests_properties( ${MODULE_NAME}-Test11-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test11 )
 
 # Test12
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test12
+            NAME ${MODULE_NAME}-Test12
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -B 5 2 0
-               -w ${TEMP}/${PROJECT_NAME}Test12.mha )
+               -w ${TEMP}/${MODULE_NAME}Test12.mha )
 
 # Test12-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test12-Compare
+            NAME ${MODULE_NAME}-Test12-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test12.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test12.mha}
+               -t ${TEMP}/${MODULE_NAME}Test12.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test12.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test12-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test12 )
+set_tests_properties( ${MODULE_NAME}-Test12-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test12 )
 
 # Test13
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test13
+            NAME ${MODULE_NAME}-Test13
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/im0001.crop2.mha}
                -z 0.7 1.4 3
-               -w ${TEMP}/${PROJECT_NAME}Test13.mha )
+               -w ${TEMP}/${MODULE_NAME}Test13.mha )
 
 # Test13-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test13-Compare
+            NAME ${MODULE_NAME}-Test13-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test13.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test13.mha}
+               -t ${TEMP}/${MODULE_NAME}Test13.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test13.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test13-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test13 )
+set_tests_properties( ${MODULE_NAME}-Test13-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test13 )
 
 # Test14
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test14
+            NAME ${MODULE_NAME}-Test14
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
-               -l 10 ${TEMP}/${PROJECT_NAME}Test14.txt )
+               -l 10 ${TEMP}/${MODULE_NAME}Test14.txt )
 
 # Test14-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test14-Compare
+            NAME ${MODULE_NAME}-Test14-Compare
             COMMAND ${TubeTK_CompareTextFiles_EXE}
-            -t ${TEMP}/${PROJECT_NAME}Test14.txt
-            -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test14.txt} )
-set_tests_properties( ${PROJECT_NAME}-Test14-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test14 )
+            -t ${TEMP}/${MODULE_NAME}Test14.txt
+            -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test14.txt} )
+set_tests_properties( ${MODULE_NAME}-Test14-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test14 )
 
 # Test15
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test15
+            NAME ${MODULE_NAME}-Test15
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
-               -L 100 -1 0.01 ${TEMP}/${PROJECT_NAME}Test15.txt )
+               -L 100 -1 0.01 ${TEMP}/${MODULE_NAME}Test15.txt )
 
 # Test15-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test15-Compare
+            NAME ${MODULE_NAME}-Test15-Compare
             COMMAND ${TubeTK_CompareTextFiles_EXE}
-            -t ${TEMP}/${PROJECT_NAME}Test15.txt
-            -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test15.txt} )
-set_tests_properties( ${PROJECT_NAME}-Test15-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test15 )
+            -t ${TEMP}/${MODULE_NAME}Test15.txt
+            -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test15.txt} )
+set_tests_properties( ${MODULE_NAME}-Test15-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test15 )
 
 # Test16
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test16
+            NAME ${MODULE_NAME}-Test16
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/CroppedWholeLungCTScan.mhd,CroppedWholeLungCTScan.raw}
                -c 100 10
-               -w ${TEMP}/${PROJECT_NAME}Test16.mha )
+               -w ${TEMP}/${MODULE_NAME}Test16.mha )
 
 # Test16-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test16-Compare
+            NAME ${MODULE_NAME}-Test16-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test16.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test16.mha}
+               -t ${TEMP}/${MODULE_NAME}Test16.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test16.mha}
                -i 0.5
                -n 300 )
-set_tests_properties( ${PROJECT_NAME}-Test16-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test16 )
+set_tests_properties( ${MODULE_NAME}-Test16-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test16 )
 
 # Test17
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test17
+            NAME ${MODULE_NAME}-Test17
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
-               -C 100 3 DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test2.mha}
-               -w ${TEMP}/${PROJECT_NAME}Test17.mha )
+               -C 100 3 DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test2.mha}
+               -w ${TEMP}/${MODULE_NAME}Test17.mha )
 
 # Test17-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test17-Compare
+            NAME ${MODULE_NAME}-Test17-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test17.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test17.mha}
+               -t ${TEMP}/${MODULE_NAME}Test17.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test17.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test17-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test17 )
+set_tests_properties( ${MODULE_NAME}-Test17-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test17 )
 
 # Test18
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test18
+            NAME ${MODULE_NAME}-Test18
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -r 2
-               -w ${TEMP}/${PROJECT_NAME}Test18.mha )
+               -w ${TEMP}/${MODULE_NAME}Test18.mha )
 
 # Test18-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test18-Compare
+            NAME ${MODULE_NAME}-Test18-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test18.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test18.mha}
+               -t ${TEMP}/${MODULE_NAME}Test18.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test18.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test18-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test18 )
+set_tests_properties( ${MODULE_NAME}-Test18-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test18 )
 
 # Test19
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test19
+            NAME ${MODULE_NAME}-Test19
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
-               -R DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test18.mha}
-               -w ${TEMP}/${PROJECT_NAME}Test19.mha )
+               -R DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test18.mha}
+               -w ${TEMP}/${MODULE_NAME}Test19.mha )
 
 # Test19-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test19-Compare
+            NAME ${MODULE_NAME}-Test19-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test19.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test19.mha}
+               -t ${TEMP}/${MODULE_NAME}Test19.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test19.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test19-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test19 )
+set_tests_properties( ${MODULE_NAME}-Test19-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test19 )
 
 # Test20
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test20
+            NAME ${MODULE_NAME}-Test20
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -s 0 -1 -0.33 1 70 50 0
-               -W 2 ${TEMP}/${PROJECT_NAME}Test20.mha )
+               -W 2 ${TEMP}/${MODULE_NAME}Test20.mha )
 
 # Test20-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test20-Compare
+            NAME ${MODULE_NAME}-Test20-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test20.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test20.mha}
+               -t ${TEMP}/${MODULE_NAME}Test20.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test20.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test20-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test20 )
+set_tests_properties( ${MODULE_NAME}-Test20-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test20 )
 
 # Test21
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test21
+            NAME ${MODULE_NAME}-Test21
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -O -10 -10 0
-               -w ${TEMP}/${PROJECT_NAME}Test21.mha )
+               -w ${TEMP}/${MODULE_NAME}Test21.mha )
 
 # Test21-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test21-Compare
+            NAME ${MODULE_NAME}-Test21-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test21.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test21.mha}
+               -t ${TEMP}/${MODULE_NAME}Test21.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test21.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test21-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test21 )
+set_tests_properties( ${MODULE_NAME}-Test21-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test21 )
 
 # Test23
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test23
+            NAME ${MODULE_NAME}-Test23
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -P 0 DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
-               -w ${TEMP}/${PROJECT_NAME}Test23.mha )
+               -w ${TEMP}/${MODULE_NAME}Test23.mha )
 
 # Test23-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test23-Compare
+            NAME ${MODULE_NAME}-Test23-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test23.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test23.mha}
+               -t ${TEMP}/${MODULE_NAME}Test23.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test23.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test23-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test23 )
+set_tests_properties( ${MODULE_NAME}-Test23-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test23 )
 
 # Test24
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test24
+            NAME ${MODULE_NAME}-Test24
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -u DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
-               -w ${TEMP}/${PROJECT_NAME}Test24.mha )
+               -w ${TEMP}/${MODULE_NAME}Test24.mha )
 
 # Test24-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test24-Compare
+            NAME ${MODULE_NAME}-Test24-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test24.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test24.mha}
+               -t ${TEMP}/${MODULE_NAME}Test24.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test24.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test24-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test24 )
+set_tests_properties( ${MODULE_NAME}-Test24-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test24 )
 
 # Test25
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test25
+            NAME ${MODULE_NAME}-Test25
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -p 0 DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
-               -w ${TEMP}/${PROJECT_NAME}Test25.mha )
+               -w ${TEMP}/${MODULE_NAME}Test25.mha )
 
 # Test25-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test25-Compare
+            NAME ${MODULE_NAME}-Test25-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test25.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test25.mha}
+               -t ${TEMP}/${MODULE_NAME}Test25.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test25.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test25-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test25 )
+set_tests_properties( ${MODULE_NAME}-Test25-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test25 )
 
 # Test26
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test26
+            NAME ${MODULE_NAME}-Test26
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -d 0
-               -w ${TEMP}/${PROJECT_NAME}Test26.mha )
+               -w ${TEMP}/${MODULE_NAME}Test26.mha )
 
 # Test26-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test26-Compare
+            NAME ${MODULE_NAME}-Test26-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test26.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test26.mha}
+               -t ${TEMP}/${MODULE_NAME}Test26.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test26.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test26-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test26 )
+set_tests_properties( ${MODULE_NAME}-Test26-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test26 )
 
 # Test27
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test27
+            NAME ${MODULE_NAME}-Test27
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -x 6
-               -w ${TEMP}/${PROJECT_NAME}Test27.mha )
+               -w ${TEMP}/${MODULE_NAME}Test27.mha )
 
 # Test27-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test27-Compare
+            NAME ${MODULE_NAME}-Test27-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test27.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test27.mha}
+               -t ${TEMP}/${MODULE_NAME}Test27.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test27.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test27-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test27 )
+set_tests_properties( ${MODULE_NAME}-Test27-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test27 )
 
 # Test28
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test28
+            NAME ${MODULE_NAME}-Test28
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -d 1
-               -w ${TEMP}/${PROJECT_NAME}Test28.mha )
+               -w ${TEMP}/${MODULE_NAME}Test28.mha )
 
 # Test28-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test28-Compare
+            NAME ${MODULE_NAME}-Test28-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test28.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test28.mha}
+               -t ${TEMP}/${MODULE_NAME}Test28.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test28.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test28-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test28 )
+set_tests_properties( ${MODULE_NAME}-Test28-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test28 )
 
 # Test29
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test29
+            NAME ${MODULE_NAME}-Test29
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -d 2
-               -w ${TEMP}/${PROJECT_NAME}Test29.mha )
+               -w ${TEMP}/${MODULE_NAME}Test29.mha )
 
 # Test29-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test29-Compare
+            NAME ${MODULE_NAME}-Test29-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test29.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test29.mha}
+               -t ${TEMP}/${MODULE_NAME}Test29.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test29.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test29-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test29 )
+set_tests_properties( ${MODULE_NAME}-Test29-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test29 )
 
 # Test30
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test30
+            NAME ${MODULE_NAME}-Test30
             COMMAND ${PROJ_EXE}
                DATA{${TubeTK_DATA_ROOT}/ES0015_Large_Subs.mha}
                -g 5
-               -w ${TEMP}/${PROJECT_NAME}Test30.mha )
+               -w ${TEMP}/${MODULE_NAME}Test30.mha )
 
 # Test30-Compare
 ExternalData_Add_Test( TubeTKData
-            NAME ${PROJECT_NAME}-Test30-Compare
+            NAME ${MODULE_NAME}-Test30-Compare
             COMMAND ${TubeTK_CompareImages_EXE}
-               -t ${TEMP}/${PROJECT_NAME}Test30.mha
-               -b DATA{${TubeTK_DATA_ROOT}/${PROJECT_NAME}Test30.mha}
+               -t ${TEMP}/${MODULE_NAME}Test30.mha
+               -b DATA{${TubeTK_DATA_ROOT}/${MODULE_NAME}Test30.mha}
                -i 0.001 )
-set_tests_properties( ${PROJECT_NAME}-Test30-Compare PROPERTIES DEPENDS
-            ${PROJECT_NAME}-Test30 )
+set_tests_properties( ${MODULE_NAME}-Test30-Compare PROPERTIES DEPENDS
+            ${MODULE_NAME}-Test30 )

--- a/apps/MergeAdjacentImages/CMakeLists.txt
+++ b/apps/MergeAdjacentImages/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME MergeAdjacentImages )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/MergeTubeGraphs/CMakeLists.txt
+++ b/apps/MergeTubeGraphs/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME MergeTubeGraphs )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/RegisterImageToTubesUsingRigidTransform/CMakeLists.txt
+++ b/apps/RegisterImageToTubesUsingRigidTransform/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME RegisterImageToTubesUsingRigidTransform )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/RegisterImages/CMakeLists.txt
+++ b/apps/RegisterImages/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME RegisterImages )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/RegisterUsingSlidingGeometries/CMakeLists.txt
+++ b/apps/RegisterUsingSlidingGeometries/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME RegisterUsingSlidingGeometries )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/ResampleImage/CMakeLists.txt
+++ b/apps/ResampleImage/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ResampleImage )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/ResampleTubes/CMakeLists.txt
+++ b/apps/ResampleTubes/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ResampleTubes )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SampleCLIApplication/CMakeLists.txt
+++ b/apps/SampleCLIApplication/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SampleCLIApplication )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SegmentBinaryImageSkeleton/CMakeLists.txt
+++ b/apps/SegmentBinaryImageSkeleton/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SegmentBinaryImageSkeleton )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SegmentBinaryImageSkeleton3D/CMakeLists.txt
+++ b/apps/SegmentBinaryImageSkeleton3D/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SegmentBinaryImageSkeleton3D )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SegmentConnectedComponents/CMakeLists.txt
+++ b/apps/SegmentConnectedComponents/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SegmentConnectedComponents )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SegmentConnectedComponentsUsingParzenPDFs/CMakeLists.txt
+++ b/apps/SegmentConnectedComponentsUsingParzenPDFs/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SegmentConnectedComponentsUsingParzenPDFs )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SegmentTubeUsingMinimalPath/CMakeLists.txt
+++ b/apps/SegmentTubeUsingMinimalPath/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SegmentTubeUsingMinimalPath )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SegmentTubes/CMakeLists.txt
+++ b/apps/SegmentTubes/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SegmentTubes )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SegmentUsingOtsuThreshold/CMakeLists.txt
+++ b/apps/SegmentUsingOtsuThreshold/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SegmentUsingOtsuThreshold )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SegmentUsingQuantileThreshold/CMakeLists.txt
+++ b/apps/SegmentUsingQuantileThreshold/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SegmentUsingQuantileThreshold )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/ShrinkImage/CMakeLists.txt
+++ b/apps/ShrinkImage/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME ShrinkImage )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/SimulateAcquisitionArtifactsUsingPrior/CMakeLists.txt
+++ b/apps/SimulateAcquisitionArtifactsUsingPrior/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME SimulateAcquisitionArtifactsUsingPrior )
 
-project( ${MODULE_NAME} )
-
 set( SimulateAcquisitionArtifactsUsingPrior_H_Files
   tubeCompareImageWithPrior.h )
 

--- a/apps/TransferLabelsToRegions/CMakeLists.txt
+++ b/apps/TransferLabelsToRegions/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME TransferLabelsToRegions )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/TreeMath/CMakeLists.txt
+++ b/apps/TreeMath/CMakeLists.txt
@@ -21,8 +21,6 @@
 ############################################################################
 set( MODULE_NAME TreeMath )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h

--- a/apps/TubeMath/CMakeLists.txt
+++ b/apps/TubeMath/CMakeLists.txt
@@ -22,8 +22,6 @@
 
 set( MODULE_NAME TubeMath )
 
-project( ${MODULE_NAME} )
-
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h


### PR DESCRIPTION
Removed the declaration of "project(MODULE_NAME)" previously
associated with each app.   The use of project caused executables
to not be moved to a common location.