### PR TITLE
ENH: Turn on building apps on Azure

### DIFF
--- a/dashboards/AzureLinuxGCC/azure-pipelines.yml
+++ b/dashboards/AzureLinuxGCC/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
         c++ --version
         cmake --version
         cd ITKTubeTK-Release
-        cmake -GNinja -DTubeTK_USE_VTK=OFF -DTubeTK_WRAP_PYTHON=OFF -DITK_DIR=$(Agent.BuildDirectory)/ITK-Release -DSlicerExecutionModel_DIR=$(Agent.BuildDirectory)/SlicerExecutionModel-Release -DCMAKE_BUILD_TYPE=Release $(Build.SourcesDirectory)
+        cmake -GNinja -DTubeTK_USE_VTK=OFF -DTubeTK_BUILD_APPLICATIONS=ON -DTubeTK_WRAP_PYTHON=OFF -DITK_DIR=$(Agent.BuildDirectory)/ITK-Release -DSlicerExecutionModel_DIR=$(Agent.BuildDirectory)/SlicerExecutionModel-Release -DCMAKE_BUILD_TYPE=Release $(Build.SourcesDirectory)
         ctest -D Experimental -V
         cd ..
       displayName: CMake and CTest ITKTubeTK

--- a/dashboards/AzureMacOSGCC/azure-pipelines.yml
+++ b/dashboards/AzureMacOSGCC/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
         c++ --version
         cmake --version
         cd ITKTubeTK-Release
-        cmake -GNinja -DTubeTK_USE_VTK=OFF -DTubeTK_WRAP_PYTHON=OFF -DITK_DIR=$(Agent.BuildDirectory)/ITK-Release -DSlicerExecutionModel_DIR=$(Agent.BuildDirectory)/SlicerExecutionModel-Release -DCMAKE_BUILD_TYPE=Release $(Build.SourcesDirectory)
+        cmake -GNinja -DTubeTK_USE_VTK=OFF -DTubeTK_BUILD_APPLICATIONS=ON -DTubeTK_WRAP_PYTHON=OFF -DITK_DIR=$(Agent.BuildDirectory)/ITK-Release -DSlicerExecutionModel_DIR=$(Agent.BuildDirectory)/SlicerExecutionModel-Release -DCMAKE_BUILD_TYPE=Release $(Build.SourcesDirectory)
         ctest -D Experimental -V
         cd ..
       displayName: CMake and CTest ITKTubeTK

--- a/dashboards/AzureWinVS/azure-pipelines.yml
+++ b/dashboards/AzureWinVS/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
       workingDirectory: $(Agent.BuildDirectory)
     - script: |
         set /p BUILDPATH=<..\buildpath
-        cmake -DTubeTK_USE_VTK=OFF -DTubeTK_WRAP_PYTHON=OFF -DITK_DIR=%BUILDPATH%/ITK-Release -DSlicerExecutionModel_DIR=%BUILDPATH%/SlicerExecutionModel-Release -DCMAKE_BUILD_TYPE=Release $(Build.SourcesDirectory)
+        cmake -DTubeTK_USE_VTK=OFF -DTubeTK_BUILD_APPLICATIONS=ON -DTubeTK_WRAP_PYTHON=OFF -DITK_DIR=%BUILDPATH%/ITK-Release -DSlicerExecutionModel_DIR=%BUILDPATH%/SlicerExecutionModel-Release -DCMAKE_BUILD_TYPE=Release $(Build.SourcesDirectory)
       displayName: CMake ITKTubeTK
       workingDirectory: $(Agent.BuildDirectory)\ITKTubeTK-Release
     - bash: |


### PR DESCRIPTION
This also requires building SlicerExecutionModel prior to building
TubeTK and requires access to ITK Source and Binary dirs.