### PR TITLE
COMP: Build Python packages against ITK v4.13.1.post1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           name: Build Python packages
           no_output_timeout: 1.0h
           command: |
-            export ITK_PACKAGE_VERSION=v4.13.1
+            export ITK_PACKAGE_VERSION=v4.13.1.post1
             ./dockcross-manylinux-download-cache-and-build-module-wheels.sh
       - store_artifacts:
           path: dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
 - pushd ITKMinimalPathExtraction
 - curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
-- export ITK_PACKAGE_VERSION=v4.13.0
+- export ITK_PACKAGE_VERSION=v4.13.1.post1
 - ./macpython-download-cache-and-build-module-wheels.sh 3.6
 - popd; popd
 - /Users/Kitware/Dashboards/ITK/ITKPythonPackage/scripts/macpython-build-module-wheels.sh 3.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ install:
   - git clone https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction
   - cd ITKMinimalPathExtraction
   - curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/windows-download-cache-and-build-module-wheels.ps1 -O
-  - ps: $env:ITK_PACKAGE_VERSION='v4.13.0' ; .\windows-download-cache-and-build-module-wheels.ps1
+  - ps: $env:ITK_PACKAGE_VERSION='v4.13.1.post1' ; .\windows-download-cache-and-build-module-wheels.ps1
   - cd ../ITKTubeTK
-  - ps: $env:ITK_PACKAGE_VERSION='v4.13.0' ; C:\Python35-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py
+  - ps: $env:ITK_PACKAGE_VERSION='v4.13.1.post1' ; C:\Python35-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py
 
 build: off
 


### PR DESCRIPTION
The ITK 4.13.1 Python package was released as "v4.13.1.post1". Build
against those ITK builds, which support using data.kitware.com instead
of midas3.kitware.com for CastXML and other resources.