### PR TITLE
COMP: Fix warnings regarding type conversion and unused vars

### DIFF
--- a/TubeTKLib/Registration/Testing/itktubeTubeParametricExponentialResolutionWeightFunctionTest.cxx
+++ b/TubeTKLib/Registration/Testing/itktubeTubeParametricExponentialResolutionWeightFunctionTest.cxx
@@ -99,9 +99,9 @@ int itktubeTubeParametricExponentialResolutionWeightFunctionTest( int argc, char
     }
 
   unsigned int numberOfAlphas = 5;
-  float alphas[] = { 5.0, 2.0, 1.0, 0.5, 0.0 };
+  double alphas[] = { 5.0, 2.0, 1.0, 0.5, 0.0 };
   unsigned int numberOfDeltas = 5;
-  float deltas[] = { 0.7, 0.5, 0.0, -0.5, -0.7 };
+  double deltas[] = { 0.7, 0.5, 0.0, -0.5, -0.7 };
 
   for( unsigned int ii = 0; ii < numberOfPoints; ++ii )
     {

--- a/TubeTKLib/Registration/Testing/itktubeTubeParametricExponentialWithBoundsResolutionWeightFunctionTest.cxx
+++ b/TubeTKLib/Registration/Testing/itktubeTubeParametricExponentialWithBoundsResolutionWeightFunctionTest.cxx
@@ -116,9 +116,9 @@ int itktubeTubeParametricExponentialWithBoundsResolutionWeightFunctionTest( int 
     }
 
   unsigned int numberOfAlphas = 5;
-  float alphas[] = { 5.0, 2.0, 1.0, 0.5, 0.0 };
+  double alphas[] = { 5.0, 2.0, 1.0, 0.5, 0.0 };
   unsigned int numberOfDeltas = 5;
-  float deltas[] = { 0.7, 0.5, 0.0, -0.5, -0.7 };
+  double deltas[] = { 0.7, 0.5, 0.0, -0.5, -0.7 };
 
   for( unsigned int ii = 0; ii < numberOfPoints; ++ii )
     {

--- a/TubeTKLib/Registration/itktubeTubeToTubeTransformFilter.hxx
+++ b/TubeTKLib/Registration/itktubeTubeToTubeTransformFilter.hxx
@@ -110,8 +110,6 @@ TubeToTubeTransformFilter< TTransformType, TDimension >
     Point<double, TDimension> transformedWorldPoint;
     Point<double, TDimension> inputPoint;
     Point<double, TDimension> outputPoint;
-    CovariantVector< double, TDimension > normal1;
-    CovariantVector< double, TDimension > normal2;
 
     inputSOAsTube->ComputeObjectToWorldTransform();
 


### PR DESCRIPTION
Assigning doubles to float - changed vars to double
Unused vars