### PR TITLE
BUG: Fix duplicate function definition from bad merge

### DIFF
--- a/TubeTKLib/Numerics/itktubeVotingResampleImageFunction.h
+++ b/TubeTKLib/Numerics/itktubeVotingResampleImageFunction.h
@@ -102,9 +102,6 @@ public:
   SizeType GetRadius() const override
     { return m_Radius; }
 
-  SizeType GetRadius() const
-    { return m_Radius; }
-
 protected:
   VotingResampleImageFunction( void );
   ~VotingResampleImageFunction( void ) {}


### PR DESCRIPTION
When merging the last commit (UpdateToITKv5), a manual merge
was required to resolve a conflict, and a bug was introduced.

This addresses that bug in itktubeVotingResampleImageFunction.h