### PR TITLE
ENH: Take advantage of support for separate python and C++ git tags

### DIFF
--- a/test/azure-pipelines.yml
+++ b/test/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   ITKGitTag: v5.0.0
-  ITKPythonPost: '.post1'
+  ITKPythonGitTag: 'v5.0.0.post1'
   CMakeBuildType: Release
 
 trigger:
@@ -157,7 +157,7 @@ jobs:
     displayName: 'Fetch build script'
 
   - script: |
-      export ITK_PACKAGE_VERSION=$(ITKGitTag)$(ITKPythonPost)
+      export ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       ./dockcross-manylinux-download-cache-and-build-module-wheels.sh
     displayName: 'Build Python packages'
 
@@ -181,7 +181,7 @@ jobs:
     displayName: 'Fetch build script'
 
   - script: |
-      export ITK_PACKAGE_VERSION=$(ITKGitTag)$(ITKPythonPost)
+      export ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       ./macpython-download-cache-and-build-module-wheels.sh
     displayName: 'Build Python packages'
 
@@ -205,7 +205,7 @@ jobs:
 
   - script: |
       call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-      set ITK_PACKAGE_VERSION=$(ITKGitTag)$(ITKPythonPost)
+      set ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       set CC=cl.exe
       set CXX=cl.exe
       powershell.exe -file .\windows-download-cache-and-build-module-wheels.ps1


### PR DESCRIPTION
Testing in Azure now allows C++ to test against one git tag of ITK while python testing is against 
a different tag.    Using so that TubeTK can track C++ master and Python latest wheel.