### PR TITLE
BUG: Fixed const-ness of transformlists and SpatialObjects

### DIFF
--- a/TubeTKLib/Filtering/itktubeResampleTubesFilter.h
+++ b/TubeTKLib/Filtering/itktubeResampleTubesFilter.h
@@ -91,7 +91,7 @@ public:
   itkSetObjectMacro( InputSpatialObject, TubeGroupType );
 
   void SetDisplacementField( DisplacementFieldType* field );
-  void SetReadTransformList( BaseTransformListType* tList );
+  void SetReadTransformList( const BaseTransformListType* tList );
 
 protected:
   ResampleTubesFilter( void );
@@ -110,7 +110,7 @@ private:
   typename ImageType::Pointer             m_MatchImage;
   int                                     m_SamplingFactor;
   bool                                    m_UseInverseTransform;
-  BaseTransformListType*                  m_ReadTransformList;
+  const BaseTransformListType*            m_ReadTransformList;
   typename DisplacementFieldType::Pointer m_DisplacementField;
   typename TubeGroupType::Pointer         m_InputSpatialObject;
 

--- a/TubeTKLib/Filtering/itktubeResampleTubesFilter.hxx
+++ b/TubeTKLib/Filtering/itktubeResampleTubesFilter.hxx
@@ -70,7 +70,7 @@ ResampleTubesFilter< VDimension >
 template< unsigned int VDimension >
 void
 ResampleTubesFilter< VDimension >
-::SetReadTransformList( BaseTransformListType * tList )
+::SetReadTransformList( const BaseTransformListType * tList )
 {
   m_ReadTransformList = tList;
 }

--- a/TubeTKLib/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.h
+++ b/TubeTKLib/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.h
@@ -133,8 +133,7 @@ protected:
    * an implementation for GenerateInputRequestedRegion in order to inform
    * the pipeline execution model.
    * \sa ImageToImageFilter::GenerateInputRequestedRegion() */
-  virtual void GenerateInputRequestedRegion( void )
-    throw( InvalidRequestedRegionError ) override;
+  virtual void GenerateInputRequestedRegion( void ) override;
 
   /** Generate Data */
   void GenerateData( void ) override;

--- a/TubeTKLib/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.hxx
+++ b/TubeTKLib/Filtering/itktubeStructureTensorRecursiveGaussianImageFilter.hxx
@@ -145,7 +145,7 @@ StructureTensorRecursiveGaussianImageFilter<TInputImage, TOutputImage>
 template< class TInputImage, class TOutputImage >
 void
 StructureTensorRecursiveGaussianImageFilter<TInputImage, TOutputImage>
-::GenerateInputRequestedRegion() throw( InvalidRequestedRegionError )
+::GenerateInputRequestedRegion()
 {
   // call the superclass' implementation of this method. this should
   // copy the output requested region to the input requested region

--- a/TubeTKLib/Registration/itkImageToImageRegistrationHelper.txx
+++ b/TubeTKLib/Registration/itkImageToImageRegistrationHelper.txx
@@ -1288,7 +1288,7 @@ ImageToImageRegistrationHelper<TImage>
 
   transformReader->Update();
 
-  TransformListType *transforms = transformReader->GetTransformList();
+  const TransformListType *transforms = transformReader->GetTransformList();
   TransformListType::const_iterator transformIt = transforms->begin();
   while( transformIt != transforms->end() )
     {

--- a/apps/ResampleTubes/ResampleTubes.cxx
+++ b/apps/ResampleTubes/ResampleTubes.cxx
@@ -82,7 +82,7 @@ int DoIt( int argc, char * argv[] )
   tubesGroup = reader->GetGroup();
   if( tubesGroup.IsNotNull() )
     {
-    tubesGroup->ComputeObjectToWorldTransform();
+    tubesGroup->Update();
     filter->SetInput( tubesGroup );
     filter->SetInputSpatialObject( tubesGroup );
     }

--- a/apps/TubeMath/TubeMath.cxx
+++ b/apps/TubeMath/TubeMath.cxx
@@ -55,7 +55,7 @@ ReadTubeFile( const char * fileName )
 
   typename SpatialObjectReaderType::GroupType::Pointer group =
     reader->GetGroup();
-  group->ComputeObjectToWorldTransform();
+  group->Update();
   return group;
 }
 
@@ -111,7 +111,7 @@ SetPropertyFromImage( typename itk::GroupSpatialObject< DimensionT >::
     if( currentTube == ALL_TUBES_CURRENT || inputTube->GetId() ==
       currentTube )
       {
-      inputTube->ComputeObjectToWorldTransform();
+      inputTube->Update();
 
       unsigned int pointListSize = inputTube->GetNumberOfPoints();
       for( unsigned int pointNum = 0; pointNum < pointListSize; ++pointNum )
@@ -180,7 +180,7 @@ SetPropertyFromImageMean( typename itk::GroupSpatialObject< DimensionT >::
     if( currentTube == ALL_TUBES_CURRENT || inputTube->GetId() ==
       currentTube )
       {
-      inputTube->ComputeObjectToWorldTransform();
+      inputTube->Update();
 
       double valAvg = 0;
       unsigned int valCount = 0;


### PR DESCRIPTION
Ubuntu18 compiler revealed bugs in const-ness between ITK and ITKTubeTK.

Also removed throw() keywords in member function declarations.