### PR TITLE
COMP: Override needed.

### DIFF
--- a/include/tubeSegmentConnectedComponentsUsingParzenPDFs.h
+++ b/include/tubeSegmentConnectedComponentsUsingParzenPDFs.h
@@ -131,7 +131,7 @@ public:
 
   tubeWrapGetNthMacro( ClassProbabilityImage, ProbabilityImageType, Filter );
 
-  void Update( void );
+  void Update( void ) override;
 
   /** Get output segmentation mask */
   tubeWrapGetObjectMacro( Output, OutputImageType, Filter );


### PR DESCRIPTION
Missing override in
include/tubeSegmentConnectedComponentsUsingParzenPDFs.h