### PR TITLE
BUG: Updated baseline for itktubeImageToTubeRigidRegistration

### DIFF
--- a/TubeTKLib/Registration/Testing/CMakeLists.txt
+++ b/TubeTKLib/Registration/Testing/CMakeLists.txt
@@ -95,7 +95,7 @@ ExternalData_Add_Test( TubeTKData
   COMMAND ${BASE_REGISTRATION_TESTS}
     itktubeImageToTubeRigidRegistrationTest
       DATA{${TubeTK_DATA_ROOT}/Branch.n020.mha}
-      DATA{${TubeTK_DATA_ROOT}/tube.tre}
+      DATA{${TubeTK_DATA_ROOT}/Branch-truth-new.tre}
       ${TEMP}/itktubeImageToTubeRigidRegistrationOutputTube.tre
       ${TEMP}/itktubeImageToTubeRigidRegistrationOutputImage.mha )
 

--- a/TubeTKLib/Registration/Testing/itktubeImageToTubeRigidRegistrationTest.cxx
+++ b/TubeTKLib/Registration/Testing/itktubeImageToTubeRigidRegistrationTest.cxx
@@ -35,7 +35,6 @@ limitations under the License.
 
 int itktubeImageToTubeRigidRegistrationTest( int argc, char * argv[] )
 {
-
   if( argc < 4 )
     {
     std::cerr << "Missing Parameters: "
@@ -158,7 +157,7 @@ int itktubeImageToTubeRigidRegistrationTest( int argc, char * argv[] )
   if( gradientDescentOptimizer )
     {
     gradientDescentOptimizer->SetLearningRate( 0.1 );
-    gradientDescentOptimizer->SetNumberOfIterations( 20 );
+    gradientDescentOptimizer->SetNumberOfIterations( 40 );
     }
 
   try
@@ -173,7 +172,6 @@ int itktubeImageToTubeRigidRegistrationTest( int argc, char * argv[] )
     }
 
   // validate the registration result
-  //! \todo validate against known real results.
   TransformType::Pointer outputTransform =
     dynamic_cast<TransformType *>( registrationMethod->GetTransform() );
   const TransformType::ParametersType lastParameters =
@@ -201,12 +199,12 @@ int itktubeImageToTubeRigidRegistrationTest( int argc, char * argv[] )
   std::cout << indent << translation[0] << " "
     << translation[1] << " " << translation[2] << std::endl;
 
-  double knownResult[] = { -0.071,
-    -0.115,
-    -0.1925,
-    -2.522,
-    2.563,
-    -6.09 };
+  double knownResult[] = { -0.0144,
+    -0.0146,
+    0.011,
+    -1.104,
+    -0.129,
+    -0.671 };
   std::cout << "Parameters: " << std::endl;
   for( unsigned int ii = 0; ii < 6; ++ii )
     {

--- a/TubeTKLib/Registration/itktubeImageToTubeRigidMetric.h
+++ b/TubeTKLib/Registration/itktubeImageToTubeRigidMetric.h
@@ -160,8 +160,10 @@ protected:
   ImageToTubeRigidMetric( void );
   virtual ~ImageToTubeRigidMetric( void );
 
-  typedef Vector< ScalarType, TubeDimension >                VectorType;
-  typedef Matrix< ScalarType, TubeDimension, TubeDimension > MatrixType;
+  typedef CovariantVector< ScalarType, TubeDimension >    CovariantVectorType;
+  typedef Vector< ScalarType, TubeDimension >             VectorType;
+
+  typedef Matrix< ScalarType, TubeDimension, TubeDimension >   MatrixType; 
 
   typedef typename TubePointType::PointType        PointType;
   typedef vnl_vector< ScalarType >                 VnlVectorType;
@@ -203,7 +205,7 @@ private:
     const ScalarType scale,
     const OutputPointType & currentPoint ) const;
   ScalarType ComputeThirdDerivatives(
-    const VectorType & v,
+    const CovariantVectorType & v,
     const ScalarType scale,
     const OutputPointType & currentPoint ) const;
 

--- a/TubeTKLib/Registration/itktubeImageToTubeRigidMetric.hxx
+++ b/TubeTKLib/Registration/itktubeImageToTubeRigidMetric.hxx
@@ -267,7 +267,8 @@ ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject, TTubeSpatialObject >
           const ScalarType scale = scalingRadius * m_Kappa;
 
           matchMeasure += m_FeatureWeights[weightCount] * std::fabs(
-            this->ComputeLaplacianMagnitude( pointIterator->GetNormal1InObjectSpace(),
+            this->ComputeLaplacianMagnitude(
+              pointIterator->GetNormal1InObjectSpace(),
               scale,
               currentPoint ) );
           }
@@ -455,9 +456,8 @@ ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject, TTubeSpatialObject >
           {
           transformedTubePoints.push_back( currentPoint );
 
-          //! \todo: these should be CovariantVectors?
-          VectorType v1;
-          VectorType v2;
+          CovariantVectorType v1;
+          CovariantVectorType v2;
           for( unsigned int ii = 0; ii < TubeDimension; ++ii )
             {
             v1[ii] = pointIterator->GetNormal1InObjectSpace()[ii];
@@ -466,16 +466,16 @@ ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject, TTubeSpatialObject >
 
           for( unsigned int ii = 0; ii < TubeDimension; ++ii )
             {
-            v1T[ii] = transformCopy->TransformVector( v1 )[ii];
-            v2T[ii] = transformCopy->TransformVector( v2 )[ii];
+            v1T[ii] = transformCopy->TransformCovariantVector( v1 )[ii];
+            v2T[ii] = transformCopy->TransformCovariantVector( v2 )[ii];
             }
           tM = outer_product( v1T, v1T );
           tM = tM + outer_product( v2T, v2T );
           tM = m_FeatureWeights[weightCount] * tM;
           biasV += tM;
 
-          v1 = transformCopy->TransformVector( v1 );
-          v2 = transformCopy->TransformVector( v2 );
+          v1 = transformCopy->TransformCovariantVector( v1 );
+          v2 = transformCopy->TransformCovariantVector( v2 );
 
           ScalarType scalingRadius = pointIterator->GetRadiusInObjectSpace();
           scalingRadius = std::max( scalingRadius, m_MinimumScalingRadius );
@@ -603,7 +603,7 @@ typename ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject,
   TTubeSpatialObject >::ScalarType
 ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject, TTubeSpatialObject >
 ::ComputeThirdDerivatives(
-  const VectorType & tubeNormal,
+  const CovariantVectorType & tubeNormal,
   const ScalarType scale,
   const OutputPointType & currentPoint ) const
 {
@@ -614,11 +614,10 @@ ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject, TTubeSpatialObject >
 
   const ScalarType scaleSquared = scale * scale;
   const ScalarType scaleExtentProduct = scale * m_Extent;
-
+  const ScalarType step = 0.1 * scaleExtentProduct;
   for( ScalarType distance = -scaleExtentProduct;
        distance <= scaleExtentProduct;
-       //! \todo better way to calculate this increment
-       distance += 0.1 )
+       distance += step )
     {
     const ScalarType distanceSquared = distance * distance;
     const ScalarType kernelValue =


### PR DESCRIPTION
In parallel with updates to ITK (pull request #1198 which updated the TubeSpatialObject's IsInside function), this update fixes the baseline for the indicated test.