### PR TITLE
BUG: Check for same size images in ConvertShrunkenSeedImageToList

### DIFF
--- a/TubeTKLib/Filtering/itktubeConvertShrunkenSeedImageToListFilter.hxx
+++ b/TubeTKLib/Filtering/itktubeConvertShrunkenSeedImageToListFilter.hxx
@@ -114,6 +114,12 @@ ConvertShrunkenSeedImageToListFilter< TImage, TPointsImage >
   const PointsImageType* inPoint =
     const_cast< PointsImageType * >( this->GetPointsImage() );
 
+  if( inImage->GetLargestPossibleRegion() != inScale->GetLargestPossibleRegion()
+    || inScale->GetLargestPossibleRegion() !=
+       inPoint->GetLargestPossibleRegion() )
+  {
+    itkExceptionMacro( << "Error: Input images must be of the same size" );
+  }
   itk::ImageRegionConstIterator< ImageType > itImage( inImage,
     inImage->GetLargestPossibleRegion() );
   itk::ImageRegionConstIterator< ImageType > itScale( inScale,


### PR DESCRIPTION
Add test and exception if the shrunken image and its parameter images
that track the scale and x,y,z coordinates in the shrunken image, don't
match in size.