### PR TITLE
BUG: Occasionally ImageMath Test 9 fails - morphological erode

### DIFF
--- a/TubeTKLib/Filtering/tubeImageMathFilters.h
+++ b/TubeTKLib/Filtering/tubeImageMathFilters.h
@@ -103,7 +103,7 @@ public:
 
   /** Mathematical morphology using a sphere. Mode: 0=erode, 1=dilate. */
   static void MorphImage( typename ImageType::Pointer & imIn, int mode,
-    float radius, float foregroundValue, float backgroundValue );
+    int radius, float foregroundValue, float backgroundValue );
 
   /** Replace values within the image, with a mask. */
   static void OverwriteImage( typename ImageType::Pointer imIn,

--- a/TubeTKLib/Filtering/tubeImageMathFilters.hxx
+++ b/TubeTKLib/Filtering/tubeImageMathFilters.hxx
@@ -711,7 +711,7 @@ void
 ImageMathFilters<VDimension>
 ::MorphImage(
     typename ImageType::Pointer & imIn,
-    int mode, float radius, float foregroundValue, float backgroundValue )
+    int mode, int radius, float foregroundValue, float backgroundValue )
 {
   typedef itk::BinaryBallStructuringElement<PixelType, VDimension>
     BallType;

--- a/apps/ImageMath/ImageMath.cxx
+++ b/apps/ImageMath/ImageMath.cxx
@@ -409,7 +409,7 @@ int DoIt( MetaCommand & command )
 
       tube::ImageMathFilters< VDimension >::MorphImage( imIn,
         command.GetValueAsInt( *it, "mode" ),
-        command.GetValueAsFloat( *it, "radius" ),
+        command.GetValueAsInt( *it, "radius" ),
         command.GetValueAsFloat( *it, "forgroundValue" ),
         command.GetValueAsFloat( *it, "backgroundValue" ) );
       }
@@ -767,7 +767,7 @@ int main( int argc, char * argv[] )
   command.SetOption( "Morphology", "M", false,
     "Mathematical morphology using a sphere. Mode: 0=erode, 1=dilate." );
   command.AddOptionField( "Morphology", "mode", MetaCommand::INT, true );
-  command.AddOptionField( "Morphology", "radius", MetaCommand::FLOAT,
+  command.AddOptionField( "Morphology", "radius", MetaCommand::INT,
     true );
   command.AddOptionField( "Morphology", "forgroundValue",
     MetaCommand::FLOAT, true );


### PR DESCRIPTION
Results are not as expected occasionally on select platforms.  Results
are inconsistent (sometimes perfect, other times with small deviations).

Using radius as int instead of float, to see if rounding/float errors
are to blame.