### PR TITLE
COMP: C++11 has deprecated the "throw" function declaration decorator

### DIFF
--- a/TubeTKLib/Registration/itktubeImageToTubeRigidMetric.h
+++ b/TubeTKLib/Registration/itktubeImageToTubeRigidMetric.h
@@ -128,7 +128,7 @@ public:
     MeasureType & Value, DerivativeType  & Derivative ) const override;
 
   /** Initialize the metric */
-  void Initialize( void ) throw ( ExceptionObject ) override;
+  void Initialize( void ) override;
 
   /** Control the radius scaling of the metric. */
   itkSetMacro( Kappa, ScalarType );

--- a/TubeTKLib/Registration/itktubeImageToTubeRigidMetric.hxx
+++ b/TubeTKLib/Registration/itktubeImageToTubeRigidMetric.hxx
@@ -87,7 +87,7 @@ template< class TFixedImage, class TMovingSpatialObject,
 void
 ImageToTubeRigidMetric< TFixedImage, TMovingSpatialObject,
   TTubeSpatialObject >
-::Initialize( void ) throw ( ExceptionObject )
+::Initialize( void )
 {
   if( !this->m_MovingSpatialObject || !this->m_FixedImage )
     {


### PR DESCRIPTION
When declaring functions in .h files and defining them (e.g., in .hxx
files), C++11 has deprecated the use of "throw(exception)" in the
function declaration statements. The message is

```
warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
 ::Initialize(void) throw ( ExceptionObject )
                    ^~~~~
```