### PR TITLE
BUG: RidgeExtractorTest2 using potentially null pointer.

### DIFF
--- a/TubeTKLib/Numerics/tubeMatrixMath.hxx
+++ b/TubeTKLib/Numerics/tubeMatrixMath.hxx
@@ -177,8 +177,14 @@ ComputeRidgeness( const vnl_matrix<T> & H,
       }
     if( closestV != ImageDimension-1 )
       {
-      std::cout << "***********Mixing things up: Chosen t=evect#"
-        << closestV << " dotProd = " << closestVDProd << std::endl;
+      std::cout << "***********Mixing things up: Chosen evect = "
+        << closestV << std::endl;
+      for( unsigned int i=0; i<ImageDimension; i++ )
+        {
+        std::cout << "   dotProd(" << i << ") = "
+          << std::fabs( dot_product( prevTangent, HEVect.get_column( i ) ) )
+          << std::endl;
+        }
       double tf = HEVal[closestV];
       HEVal[closestV] = HEVal[ImageDimension-1];
       HEVal[ImageDimension-1] = tf;

--- a/TubeTKLib/Segmentation/itktubeRidgeExtractor.hxx
+++ b/TubeTKLib/Segmentation/itktubeRidgeExtractor.hxx
@@ -479,7 +479,7 @@ RidgeExtractor<TInputImage>
     {
     std::cout << "  Scale = " << m_DataFunc->GetScale() << std::endl;
     std::cout << "  X = " << m_X << std::endl;
-    std::cout << "  XIV = " << m_XIV << std::endl;
+    std::cout << "  XI = " << m_XIV << std::endl;
     std::cout << "  XD = " << m_XD << std::endl;
     std::cout << "  XH = " << m_XH << std::endl;
     }
@@ -1795,7 +1795,8 @@ RidgeExtractor<TInputImage>
   m_InputImage->TransformPhysicalPointToContinuousIndex( lX, lXI );
   if( verbose || this->GetDebug() )
     {
-    std::cout << "*** Ridge found at " << lXI << std::endl;
+    std::cout << "*** Ridge found at index = " << lXI << std::endl;
+    std::cout << "*** Ridge found at x = " << lX << std::endl;
     }
 
   IndexType indx;


### PR DESCRIPTION
If RidgeExtractor returned null (e.g., ridge too short) then the test
would segment fault because it would attempt to use that null pointer.