### PR TITLE
BUG: CompareImages failed to generate baselines

### DIFF
--- a/TubeTKLib/CompareTools/CompareImages.cxx
+++ b/TubeTKLib/CompareTools/CompareImages.cxx
@@ -339,10 +339,9 @@ int RegressionTestImage ( const char *testImageFilename,
     region.SetSize( size );
 
     ExtractType::Pointer extract = ExtractType::New();
-    extract->SetDirectionCollapseToSubmatrix();
-
     extract->SetInput( rescale->GetOutput() );
     extract->SetExtractionRegion( region );
+    extract->SetDirectionCollapseToIdentity();
 
     WriterType::Pointer writer = WriterType::New();
       writer->SetInput( extract->GetOutput() );


### PR DESCRIPTION
If the direction matrix had swapped direction in the input image,
then the SubMatrix option for ExtractImageFilter would fail.  This
commit changes it to use SetIdentity.   Output images seem valid.