### PR TITLE
ENH: Move install-target specification for TubeTKLib into TubeTKLib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,8 +292,8 @@ include_directories( ${TubeTK_SYSTEM_INCLUDE_DIRS} )
 
 add_subdirectory( TubeTKLib )
 
-install( TARGETS ${TubeTKLib_LIBRARIES} EXPORT TubeTKLib-targets
-  ARCHIVE DESTINATION lib )
+#install( TARGETS ${TubeTKLib_LIBRARIES} EXPORT TubeTKLib-targets
+  #ARCHIVE DESTINATION lib )
 
 install( EXPORT TubeTKLib-targets DESTINATION lib/cmake )
 

--- a/TubeTKLib/Common/CMakeLists.txt
+++ b/TubeTKLib/Common/CMakeLists.txt
@@ -38,12 +38,16 @@ add_library( TubeTKLibCommon
   ${TubeTKLib_Base_Common_H_Files}
   ${TubeTKLib_Base_Common_HXX_Files}
   ${TubeTKLib_Base_Common_CXX_Files} )
+
 target_link_libraries( TubeTKLibCommon
   ${ITK_LIBRARIES} )
 target_include_directories( TubeTKLibCommon PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> )
-include_directories(
-  ${ITK_INCLUDE_DIRS} )
+
+include_directories( ${ITK_INCLUDE_DIRS} )
+
+install( TARGETS TubeTKLibCommon EXPORT TubeTKLib-targets
+  ARCHIVE DESTINATION lib )
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/TubeTKLib/Filtering/CMakeLists.txt
+++ b/TubeTKLib/Filtering/CMakeLists.txt
@@ -115,12 +115,17 @@ if( TubeTK_USE_ARRAYFIRE )
 endif()
 
 add_library( TubeTKLibFiltering INTERFACE )
+
 target_include_directories( TubeTKLibFiltering INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>" )
 target_link_libraries( TubeTKLibFiltering INTERFACE
-  TubeTKLibNumerics )
-include_directories(
- ${ITK_INCLUDE_DIRS} )
+  TubeTKLibNumerics
+  ${ITK_LIBRARIES} )
+
+include_directories( ${ITK_INCLUDE_DIRS} )
+
+install( TARGETS TubeTKLibFiltering EXPORT TubeTKLib-targets
+  ARCHIVE DESTINATION lib )
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/TubeTKLib/IO/CMakeLists.txt
+++ b/TubeTKLib/IO/CMakeLists.txt
@@ -58,11 +58,16 @@ target_link_libraries( TubeTKLibIO INTERFACE
   TubeTKLibMetaIO
   TubeTKLibCommon
   TubeTKLibNumerics
-  TubeTKLibSegmentation )
+  TubeTKLibSegmentation
+  ${ITK_LIBRARIES} )
 
 target_include_directories( TubeTKLibIO INTERFACE
-  ${ITK_INCLUDE_DIRS}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>" )
+
+include_directories( ${ITK_INCLUDE_DIRS} )
+
+install( TARGETS TubeTKLibIO EXPORT TubeTKLib-targets
+  ARCHIVE DESTINATION lib )
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/TubeTKLib/MetaIO/CMakeLists.txt
+++ b/TubeTKLib/MetaIO/CMakeLists.txt
@@ -42,12 +42,16 @@ add_library( TubeTKLibMetaIO STATIC
   ${TubeTKLib_Base_MetaIO_SRCS} )
 
 target_link_libraries( TubeTKLibMetaIO PUBLIC
-  TubeTKLibCommon )
+  TubeTKLibCommon
+  ${ITK_LIBRARIES} )
 
 target_include_directories( TubeTKLibMetaIO PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> )
-include_directories(
-  ${ITK_INCLUDE_DIRS} )
+
+include_directories( ${ITK_INCLUDE_DIRS} )
+
+install( TARGETS TubeTKLibMetaIO EXPORT TubeTKLib-targets
+  ARCHIVE DESTINATION lib )
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/TubeTKLib/Numerics/CMakeLists.txt
+++ b/TubeTKLib/Numerics/CMakeLists.txt
@@ -94,8 +94,10 @@ target_link_libraries( TubeTKLibNumerics PUBLIC
 target_include_directories( TubeTKLibNumerics PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> )
 
-include_directories(
-  ${ITK_INCLUDE_DIRS} )
+include_directories( ${ITK_INCLUDE_DIRS} )
+
+install( TARGETS TubeTKLibNumerics EXPORT TubeTKLib-targets
+  ARCHIVE DESTINATION lib )
 
 ####
 # Do testing

--- a/TubeTKLib/ObjectDocuments/CMakeLists.txt
+++ b/TubeTKLib/ObjectDocuments/CMakeLists.txt
@@ -48,15 +48,15 @@ add_library( TubeTKLibObjectDocuments STATIC
 
 target_link_libraries( TubeTKLibObjectDocuments PUBLIC
   TubeTKLibCommon
-  ${ITK_LIBRARIES}
-  ITKIOMeta
-  ITKIOSpatialObjects )
+  ${ITK_LIBRARIES} )
 
 target_include_directories( TubeTKLibObjectDocuments PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> )
 
-include_directories(
-  ${ITK_INCLUDE_DIRS} )
+include_directories( ${ITK_INCLUDE_DIRS} )
+
+install( TARGETS TubeTKLibObjectDocuments EXPORT TubeTKLib-targets
+  ARCHIVE DESTINATION lib )
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/TubeTKLib/Registration/CMakeLists.txt
+++ b/TubeTKLib/Registration/CMakeLists.txt
@@ -59,14 +59,15 @@ add_library( TubeTKLibRegistration INTERFACE )
 
 target_include_directories( TubeTKLibRegistration INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>" )
-
 target_link_libraries( TubeTKLibRegistration INTERFACE
   TubeTKLibFiltering
   TubeTKLibNumerics
-  )
+  ${ITK_LIBRARIES} )
 
-include_directories(
-  ${ITK_INCLUDE_DIRS} )
+include_directories( ${ITK_INCLUDE_DIRS} )
+
+install( TARGETS TubeTKLibRegistration EXPORT TubeTKLib-targets
+  ARCHIVE DESTINATION lib )
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/TubeTKLib/Segmentation/CMakeLists.txt
+++ b/TubeTKLib/Segmentation/CMakeLists.txt
@@ -67,12 +67,6 @@ endif()
 
 add_library( TubeTKLibSegmentation INTERFACE )
 
-target_include_directories( TubeTKLibSegmentation INTERFACE
-  ${CMAKE_CURRENT_SOURCE_DIR} )
-
-include_directories(
-  ${ITK_INCLUDE_DIRS} )
-
 target_link_libraries( TubeTKLibSegmentation INTERFACE
    TubeTKLibIO
    TubeTKLibMetaIO
@@ -80,6 +74,13 @@ target_link_libraries( TubeTKLibSegmentation INTERFACE
    TubeTKLibNumerics
    MinimalPathExtraction
    ${ITK_LIBRARIES} )
+target_include_directories( TubeTKLibSegmentation INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>" )
+
+include_directories( ${ITK_INCLUDE_DIRS} )
+
+install( TARGETS TubeTKLibSegmentation EXPORT TubeTKLib-targets
+  ARCHIVE DESTINATION lib )
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/apps/ComputeImageToTubeRigidMetricImage/CMakeLists.txt
+++ b/apps/ComputeImageToTubeRigidMetricImage/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOSpatialObjects
-    ITKIOMeta
     TubeTKLibCommon
     TubeTKLibNumerics
   )

--- a/apps/ComputeSegmentTubesParameters/CMakeLists.txt
+++ b/apps/ComputeSegmentTubesParameters/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
     TubeTKLibNumerics
     TubeTKLibMetaIO

--- a/apps/ComputeTrainingMask/CMakeLists.txt
+++ b/apps/ComputeTrainingMask/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/ComputeTubeFlyThroughImage/CMakeLists.txt
+++ b/apps/ComputeTubeFlyThroughImage/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/ComputeTubeProbability/CMakeLists.txt
+++ b/apps/ComputeTubeProbability/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/ComputeTubeTortuosityMeasures/CMakeLists.txt
+++ b/apps/ComputeTubeTortuosityMeasures/CMakeLists.txt
@@ -30,8 +30,6 @@ SEMMacroBuildCLI(
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
     ${VTK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
     TubeTKLibNumerics
   )

--- a/apps/ConvertImagesToCSV/CMakeLists.txt
+++ b/apps/ConvertImagesToCSV/CMakeLists.txt
@@ -30,7 +30,6 @@ SEMMacroBuildCLI(
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
     TubeTKLibCommon
-    ITKIOSpatialObjects
   )
 
 if( BUILD_TESTING )

--- a/apps/ConvertTRE/CMakeLists.txt
+++ b/apps/ConvertTRE/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/ConvertTubesToDensityImage/CMakeLists.txt
+++ b/apps/ConvertTubesToDensityImage/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
   )
 
 if( BUILD_TESTING )

--- a/apps/ConvertTubesToImage/CMakeLists.txt
+++ b/apps/ConvertTubesToImage/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/ConvertTubesToSurface/CMakeLists.txt
+++ b/apps/ConvertTubesToSurface/CMakeLists.txt
@@ -41,8 +41,6 @@ SEMMacroBuildCLI(
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
     ${VTK_LIBRARIES}
-    ITKIOMeta
-    ITKSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/ConvertTubesToTubeGraph/CMakeLists.txt
+++ b/apps/ConvertTubesToTubeGraph/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/ConvertTubesToTubeTree/CMakeLists.txt
+++ b/apps/ConvertTubesToTubeTree/CMakeLists.txt
@@ -29,8 +29,6 @@ SEMMacroBuildCLI(
     ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
     TubeTKLibNumerics
   )

--- a/apps/CropTubes/CMakeLists.txt
+++ b/apps/CropTubes/CMakeLists.txt
@@ -27,8 +27,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/EnhanceTubesUsingDiscriminantAnalysis/CMakeLists.txt
+++ b/apps/EnhanceTubesUsingDiscriminantAnalysis/CMakeLists.txt
@@ -39,8 +39,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKOptimizers
     TubeTKLibCommon
     TubeTKLibMetaIO
     ${${MODULE_NAME}_EXTERNAL_LIBS}

--- a/apps/EnhanceUsingNJetDiscriminantAnalysis/CMakeLists.txt
+++ b/apps/EnhanceUsingNJetDiscriminantAnalysis/CMakeLists.txt
@@ -27,7 +27,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
     TubeTKLibCommon
     TubeTKLibNumerics
     TubeTKLibMetaIO

--- a/apps/ExtractMetricImageSlice/CMakeLists.txt
+++ b/apps/ExtractMetricImageSlice/CMakeLists.txt
@@ -27,8 +27,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOSpatialObjects
-    ITKIOMeta
     TubeTKLibCommon
   )
 

--- a/apps/ImageMath/CMakeLists.txt
+++ b/apps/ImageMath/CMakeLists.txt
@@ -27,7 +27,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
     TubeTKLibCommon
   )
 

--- a/apps/MergeAdjacentImages/CMakeLists.txt
+++ b/apps/MergeAdjacentImages/CMakeLists.txt
@@ -27,8 +27,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKOptimizers
-    ITKIOTransformBase
     TubeTKLibCommon
   )
 

--- a/apps/RegisterImageToTubesUsingRigidTransform/CMakeLists.txt
+++ b/apps/RegisterImageToTubesUsingRigidTransform/CMakeLists.txt
@@ -27,8 +27,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOSpatialObjects
-    ITKIOMeta
     TubeTKLibCommon
     TubeTKLibNumerics
   )

--- a/apps/RegisterImages/CMakeLists.txt
+++ b/apps/RegisterImages/CMakeLists.txt
@@ -27,6 +27,4 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKOptimizers
-    ITKIOTransformBase
   )

--- a/apps/RegisterUsingSlidingGeometries/CMakeLists.txt
+++ b/apps/RegisterUsingSlidingGeometries/CMakeLists.txt
@@ -28,8 +28,6 @@ SEMMacroBuildCLI(
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
     ${VTK_LIBRARIES}
-    ITKIOMeta
-    ITKSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/ResampleTubes/CMakeLists.txt
+++ b/apps/ResampleTubes/CMakeLists.txt
@@ -27,8 +27,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKSpatialObjects
     TubeTKLibCommon
   )
 

--- a/apps/SegmentTubeUsingMinimalPath/CMakeLists.txt
+++ b/apps/SegmentTubeUsingMinimalPath/CMakeLists.txt
@@ -27,16 +27,9 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
-    ITKIOImageBase
     TubeTKLibCommon
     TubeTKLibNumerics
   )
-    #MinimalPathExtraction
-  #INCLUDE_DIRECTORIES
-    #"${MinimalPathExtraction_INCLUDE_DIRS}"
-    #"${MinimalPathExtraction_BINARY_DIR}/include"
 
 if( BUILD_TESTING )
   add_subdirectory( Testing )

--- a/apps/SegmentTubes/CMakeLists.txt
+++ b/apps/SegmentTubes/CMakeLists.txt
@@ -27,8 +27,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKIOSpatialObjects
     TubeTKLibCommon
     TubeTKLibNumerics
     TubeTKLibMetaIO

--- a/apps/SimulateAcquisitionArtifactsUsingPrior/CMakeLists.txt
+++ b/apps/SimulateAcquisitionArtifactsUsingPrior/CMakeLists.txt
@@ -37,9 +37,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKStatistics
-    ITKOptimizers
-    ITKIOTransformBase
     TubeTKLibCommon
     TubeTKLibNumerics
   )

--- a/apps/TubeMath/CMakeLists.txt
+++ b/apps/TubeMath/CMakeLists.txt
@@ -27,8 +27,6 @@ SEMMacroBuildCLI(
   LOGO_HEADER ${TubeTK_SOURCE_DIR}/docs/TubeTKLogo.h
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
-    ITKIOMeta
-    ITKSpatialObjects
     TubeTKLibCommon
     TubeTKLibNumerics
   )


### PR DESCRIPTION
When building as an external remote module, install-target specification must
occur within the CMakeLists.txt that declares the target.