### PR TITLE
BUG: Re-enable arrayfire support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ set( TubeTKLib_CompareTextFiles_EXE
 ####
 set( TubeTKLib_LIBRARIES
   TubeTKLibCommon
+  TubeTKLibFiltering
   TubeTKLibMetaIO
   TubeTKLibNumerics
   TubeTKLibObjectDocuments )
@@ -262,6 +263,11 @@ set( TubeTKLib_INCLUDE_DIRS
   $<INSTALL_INTERFACE:include/TubeTKLib/ObjectDocuments>
   $<INSTALL_INTERFACE:include/TubeTKLib/Registration>
   $<INSTALL_INTERFACE:include/TubeTKLib/Segmentation> )
+
+if( TubeTK_USE_ARRAYFIRE )
+  list( APPEND TubeTKLib_INCLUDE_DIRS
+    ${ArrayFire_INCLUDE_DIRS} )
+endif()
 
 ####
 # TubeTK includes TubeTKLib's libraries and include directories

--- a/TubeTKLib/Segmentation/itktubeRidgeExtractor.hxx
+++ b/TubeTKLib/Segmentation/itktubeRidgeExtractor.hxx
@@ -29,10 +29,6 @@ limitations under the License.
 #ifndef __itktubeRidgeExtractor_hxx
 #define __itktubeRidgeExtractor_hxx
 
-#ifdef WIN32
-#define _CRT_SECURE_NO_DEPRECATE
-#endif
-
 #include "tubeMessage.h"
 #include "tubeMatrixMath.h"
 #include "itktubeRidgeExtractor.h"

--- a/apps/ComputeTubeMeasures/CMakeLists.txt
+++ b/apps/ComputeTubeMeasures/CMakeLists.txt
@@ -30,6 +30,7 @@ SEMMacroBuildCLI(
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
     TubeTKLibCommon
+    TubeTKLibFiltering
   )
 
 #if( BUILD_TESTING )

--- a/apps/EnhanceTubesUsingDiscriminantAnalysis/CMakeLists.txt
+++ b/apps/EnhanceTubesUsingDiscriminantAnalysis/CMakeLists.txt
@@ -40,6 +40,7 @@ SEMMacroBuildCLI(
   TARGET_LIBRARIES
     ${ITK_LIBRARIES}
     TubeTKLibCommon
+    TubeTKLibFiltering
     TubeTKLibMetaIO
     ${${MODULE_NAME}_EXTERNAL_LIBS}
   )


### PR DESCRIPTION
Needed to update paths associated with TubeTK libraries and interfaces
to support use of arrayfire in Python-wrapped modules.